### PR TITLE
Fix Failed Pipeline Deployment

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -25,4 +25,4 @@ jobs:
         - run: coverage report -m
   
   # sam deploy
-        - run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name SchedulerBackend --s3-bucket carletonschedulingtool --capabilities CAPABILITY_IAM --region us-east-1 --parameter-overrides 'executionRole=${{ secrets.TEST_DB_EXECUTION_ROLE }}'
+        - run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name SchedulerBackend --s3-bucket carletonschedulingtool --capabilities CAPABILITY_IAM --region us-east-1

--- a/backend-template.yaml
+++ b/backend-template.yaml
@@ -10,11 +10,6 @@ Globals:
   Function:
     Timeout: 3
 
-Parameters:
-  executionRole:
-    Type: String
-    Description: ARN of the IAM role for execution
-
 Resources:
   GenerateSchedulesFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -22,9 +17,11 @@ Resources:
       CodeUri: Backend/
       Handler: src.endpoints.generate_schedules_lambda_handler
       Runtime: python3.11
-      Role: !Ref executionRole
       Architectures:
       - x86_64
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: carleton-courses-test
       Events:
         GenerateSchedules:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api


### PR DESCRIPTION
Fixed broken pipeline by removing the execution role from the Lambda. I instead just add the "DynamoDBCrudPolicy" to the default execution role.