### PR TITLE
trim, renaming, clear courses when switching terms

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "schedular",
+  "name": "scheduler",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "schedular",
+      "name": "scheduler",
       "version": "0.1.0",
       "dependencies": {
         "@fullcalendar/core": "^6.1.9",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "schedular",
+  "name": "scheduler",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/Frontend/public/index.html
+++ b/Frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Carleton Scheduler</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/Frontend/public/manifest.json
+++ b/Frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Raven's Schedular",
-  "name": "Carleton University Schedular",
+  "short_name": "Raven's Scheduler",
+  "name": "Carleton University Scheduler",
   "icons": [
     {
       "src": "favicon.ico",

--- a/Frontend/src/App.js
+++ b/Frontend/src/App.js
@@ -4,7 +4,7 @@ import FormComponent from './components/FormComponent';
 const App = () => {
   return (
     <div>
-      <h1>Carleton University Schedular</h1>
+      <h1>Carleton University Scheduler</h1>
       <FormComponent />
     </div>
   );

--- a/Frontend/src/components/FormComponent.js
+++ b/Frontend/src/components/FormComponent.js
@@ -5,9 +5,7 @@ import '../styles/FormComponent.css';
 import Calendar from './CalendarComponent'
 import { fetchCourses, fetchSchedules, fetchTerms } from '../requests';
 
-//const coursesList = ["SYSC 4001", "SYSC 3303B", "SYSC 4106", "COMP 3005", "ECOR 4995A", "SYSC 4120C", "SYSC 4907"];
 const daysOffList = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
-
 
 const initialFormState = {
     course1: '',
@@ -79,6 +77,23 @@ const FormComponent = () => {
             .length;
         setNoneEmptyCoursesCount(count);
     }, [inputValues]);
+
+    useEffect(() => {
+        const clearCourseValues = () => {
+            setInputValues((prevInputValues) => {
+                const newInputValues = { ...prevInputValues };
+                Object.keys(newInputValues)
+                    .filter((key) => /^course\d+$/.test(key))
+                    .forEach((courseKey) => {
+                        newInputValues[courseKey] = '';
+                    });
+                return newInputValues;
+            });
+        };
+        // Clear course values when the term changes
+        clearCourseValues();
+
+    }, [inputValues.term]);
 
     const handleInputChange = (inputName, selectedOption) => {
         const selectedTerm = selectedOption ? selectedOption.value : '';

--- a/Frontend/src/requests.js
+++ b/Frontend/src/requests.js
@@ -113,7 +113,7 @@ const getCourseSection = (course) => {
 
 const trimCourseSection = (course) => {
     if (isNaN(course.slice(-1))) {
-        return course.slice(0, -1);
+        return course.slice(0, -1).trim();
     }
     return course;
 };


### PR DESCRIPTION
- Trim white space from course code when formatting POST request
- Rename "schedular" to "scheduler"
- useEffect to clear selected courses when you switch terms