### PR TITLE
Removed Insights from Backend Template File

### DIFF
--- a/backend-template.yaml
+++ b/backend-template.yaml
@@ -73,19 +73,6 @@ Resources:
             Path: /getCourses
             Method: get
 
-  ApplicationResourceGroup:
-    Type: AWS::ResourceGroups::Group
-    Properties:
-      Name:
-        Fn::Sub: ApplicationInsights-SAM-${AWS::StackName}
-      ResourceQuery:
-        Type: CLOUDFORMATION_STACK_1_0
-  ApplicationInsightsMonitoring:
-    Type: AWS::ApplicationInsights::Application
-    Properties:
-      ResourceGroupName:
-        Ref: ApplicationResourceGroup
-      AutoConfigurationEnabled: 'true'
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
   # Find out more about other implicit resources you can reference within SAM


### PR DESCRIPTION
Removed Insights from Backend Template File since we are nearing the free tier limit for "alarm metrics" and I don't think our current alarms are necessary (see below):
![image](https://github.com/ConnorMarcus/CarletonClassScheduler/assets/73544123/a9327959-73e6-4caa-b2c0-5a599bde856a)

Also, it seems we went over the limit for "$0.01 per 1,000 metrics requested using GetMetricData API - US East (Northern Virginia)". I think this is due to the additional Lambda Functions that were added. Are the "delete-db-test" and "test-db-insert" Lambda functions still being used or can they be removed?
