### PR TITLE
Updated image clean up script and added unit tests

### DIFF
--- a/WebScraping/scripts/image_clean_up.py
+++ b/WebScraping/scripts/image_clean_up.py
@@ -1,9 +1,12 @@
 import os
 import boto3
 
-repository_name = os.environ.get("REPO_NAME")
-
-def delete_all_ecr_images(repository_name):
+def delete_all_ecr_images(repository_name: str) -> None:
+    # Make sure REPO_NAME env var is found
+    if repository_name == "":
+        print("Missing Repository Env Variable!")
+        return
+    
     ecr = boto3.client("ecr")
 
     # List the images in the repository
@@ -18,5 +21,6 @@ def delete_all_ecr_images(repository_name):
     
     print("Deleted all image(s)")
 
-if __name__ == "__main__":
-    delete_all_ecr_images(repository_name)
+# Run the script
+repository_name = os.environ.get("REPO_NAME", "")
+delete_all_ecr_images(repository_name)

--- a/WebScraping/tests/unit/test_image_clean_up_script.py
+++ b/WebScraping/tests/unit/test_image_clean_up_script.py
@@ -1,0 +1,30 @@
+from WebScraping.scripts.image_clean_up import *
+from unittest.mock import Mock, patch
+
+TEST_REPO_NAME = "TestRepo"
+
+def test_delete_all_ecr_images():
+  with patch("boto3.client") as mock_client:
+    mock_ecr = Mock()
+    mock_client.return_value = mock_ecr
+
+    mock_ecr.list_images.return_value = {"imageIds": ["image_id_1", "image_id_2"]}
+    mock_ecr.batch_delete_image.return_value = {"imageIds": ["image_id_1", "image_id_2"]}
+
+    delete_all_ecr_images(TEST_REPO_NAME)
+
+    mock_ecr.list_images.assert_called_once_with(repositoryName=TEST_REPO_NAME)
+    mock_ecr.batch_delete_image.assert_called_once_with(repositoryName=TEST_REPO_NAME, imageIds=["image_id_1", "image_id_2"])
+
+
+def test_delete_all_ecr_images_no_images():
+  with patch("boto3.client") as mock_client:
+    mock_ecr = Mock()
+    mock_client.return_value = mock_ecr
+
+    mock_ecr.list_images.return_value = {"imageIds": []}
+
+    delete_all_ecr_images(TEST_REPO_NAME)
+
+    mock_ecr.list_images.assert_called_once_with(repositoryName=TEST_REPO_NAME)
+    mock_ecr.batch_delete_image.assert_not_called()


### PR DESCRIPTION
The image clean up script was updated with the following few changes: 1: a default value (empty string) was added to the  os.environ.get to handle a missing REPO_NAME env var (make it more robust) + 2: the if __name__ == "__main__" block was removed since the script is never imported into another module (so it does not need to be handled differently) + 3: addition of type hints.

Following these updates unit tests were created for the script which achieved 100% coverage