### PR TITLE
Display async courses under calendar

### DIFF
--- a/Frontend/src/components/CalendarComponent.js
+++ b/Frontend/src/components/CalendarComponent.js
@@ -4,7 +4,7 @@ import timeGridPlugin from '@fullcalendar/timegrid';
 import '../styles/CalendarComponent.css';
 
 
-const MyCalendar = ({ title, events }) => {
+const MyCalendar = ({ title, events, asyncCourses }) => {
     const [scheduleCount, setScheduleCount] = useState(0);
 
     const handlePrevClick = () => {
@@ -33,11 +33,17 @@ const MyCalendar = ({ title, events }) => {
                 slotMaxTime={"23:00:00"}
                 dayHeaderFormat={{ weekday: 'long' }}
                 height="auto"
-                headerToolbar={false} //Hide the previous/next week buttons, MAY ENABLE THEM LATER
+                headerToolbar={false} //Remove this to enable cycling between weeks
                 events={events[scheduleCount]}
             //eventColor="#BF122B"
             //eventBackgroundColor='#BF122B'
             />
+            <div className="async-courses">
+                {asyncCourses[scheduleCount].length !== 0 && (<p>Courses without assigned meeting times</p>)}
+                {asyncCourses[scheduleCount]?.map((course, index) => (
+                    <p key={index}><b>{course}</b></p>
+                ))}
+            </div>
         </div>
     );
 };

--- a/Frontend/src/requests.js
+++ b/Frontend/src/requests.js
@@ -166,10 +166,24 @@ const assignColoursToEvents = (events, colours) => {
     });
 }
 
+/* If date is in format 'Jan 8, 24' coverts it to 2024-01-08
+const convertDateStr = dateString => {
+
+    var dateObject = new Date(dateString);
+
+    var year = dateObject.getFullYear();
+    var month = (dateObject.getMonth() + 1).toString().padStart(2, '0'); // Months are 0-based
+    var day = dateObject.getDate().toString().padStart(2, '0');
+    return year + "-" + month + "-" + day;
+};
+*/
+
 export const parseScheduleIntoEvents = (schedules) => {
     const events = [];
+    const asyncEvents = [];
     schedules.forEach(schedule => {
         const eventsForCurrentSchedule = [];
+        const asyncCoursesForCurrentSchedule = [];
         schedule.forEach(courseData => {
             const courseCode = courseData.CourseCode;
             const section = courseData.SectionID;
@@ -179,12 +193,19 @@ export const parseScheduleIntoEvents = (schedules) => {
                     startTime: `${time.StartTime}:00`,
                     endTime: `${time.EndTime}:00`,
                     daysOfWeek: [convertDayToInt(time.DayOfWeek)],
+                    //startRecur: convertDateStr('Jan 08, 2024'),
+                    //endRecur: convertDateStr('Apr 15, 2024'),
+                    // will eventually be like this --> startRecur: time.StartDate,
                 }
                 eventsForCurrentSchedule.push(event);
             });
+            if (courseData.Times.length === 0) {
+                asyncCoursesForCurrentSchedule.push(courseCode.concat(section))
+            }
         });
         assignColoursToEvents(eventsForCurrentSchedule, colours);
         events.push(eventsForCurrentSchedule);
+        asyncEvents.push(asyncCoursesForCurrentSchedule)
     });
-    return events;
+    return [events, asyncEvents];
 };


### PR DESCRIPTION
**IGNORE BRANCH NAME** 
Commits also include more catch blocks

I will add the ability to cycle through the calendar weeks later once the backend responds to requests with the startDate and endDate of a course. 