### PR TITLE
Added Start and End date to section data

### DIFF
--- a/Backend/src/database/database.py
+++ b/Backend/src/database/database.py
@@ -35,6 +35,8 @@ class Database:
     day_of_week_column = "DayOfWeek"
     start_time_column = "StartTime"
     end_time_column = "EndTime"
+    start_date_column = "StartDate"
+    end_date_column = "EndDate"
 
     
     def __init__(self):
@@ -80,12 +82,14 @@ class Database:
         crn = section_map.get(self.crn_column, "")
         status = section_map.get(self.status_column, "")
         instructor = section_map.get(self.instructor_column, "")
+        start_date = section_map.get(self.start_date_column, "")
+        end_date = section_map.get(self.end_date_column, "")
         related_sections = section_map.get(self.also_register_column, [])
         term_duration = TermDuration(section_map.get(self.duration_column))
         week_schedule = WeekSchedule(section_map.get(self.week_schedule_column, WeekSchedule.EVERY_WEEK))
         meeting_dates_list = section_map.get(self.meeting_dates_column, [])
         meeting_times = [self.convert_to_classtime(term_duration, meeting_date_map, week_schedule) for meeting_date_map in meeting_dates_list]
-        return Section(course_code, section_id, crn, instructor, meeting_times, status, related_sections)
+        return Section(course_code, section_id, crn, instructor, meeting_times, status, related_sections, start_date, end_date)
 
     def convert_to_classtime(self, term_duration: TermDuration, meeting_date_map: dict, week_schedule: WeekSchedule) -> ClassTime:
         day_of_week = DayOfWeek(meeting_date_map.get(self.day_of_week_column))

--- a/Backend/src/model/section.py
+++ b/Backend/src/model/section.py
@@ -12,8 +12,10 @@ class Section:
     status: str
     related_section_ids: List[List[str]] # Section IDs that must registered in with the given section 
                                          # i.e. [["ETU"], ["L1", "L2"]] would represent ETU and (L1 or L2)
+    start_date: str
+    end_date: str
 
     def to_dict(self) -> dict:
         return {"CourseCode":self.course_code, "SectionID":self.section_id, "CRN":self.crn, 
                 "Instructor":self.instructor, "Times":[time.to_dict() for time in self.times],
-                "Status":self.status}
+                "Status":self.status, "StartDate": self.start_date, "EndDate": self.end_date}

--- a/Backend/tests/unit/test_course.py
+++ b/Backend/tests/unit/test_course.py
@@ -7,8 +7,8 @@ from Backend.src.model.filter import Filter
 from Backend.src.model.term_duration import TermDuration
 
 def test_filter_before_time():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", []) 
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", [], "2023-09-06", "2023-12-08") 
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
 
     course.filter_before_time("13:00")
@@ -19,8 +19,8 @@ def test_filter_before_time():
         course.filter_before_time(12.00)
 
 def test_filter_after_time():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", []) 
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", [], "2023-09-06", "2023-12-08") 
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
 
     course.filter_after_time("13:00")
@@ -31,8 +31,8 @@ def test_filter_after_time():
         course.filter_after_time(10)
 
 def test_filter_day_off():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", []) 
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08") 
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
 
     course.filter_day_off(DayOfWeek.MONDAY)
@@ -44,8 +44,8 @@ def test_filter_day_off():
 
 
 def test_filter_by_section():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
 
     course.filter_by_section()
@@ -57,10 +57,10 @@ def test_filter_by_section():
         course.filter_by_section()
 
 def test_filter_all_courses():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section3 = Section("CODE2000", "A", "11111", "JON", [ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "07:00", "12:00")], "OPEN", [])
-    section4 = Section("CODE2000", "B", "22222", "JON", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE2000", "A", "11111", "JON", [ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "07:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE2000", "B", "22222", "JON", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
     course2 = Course("CODE2000", "CLASS NAME 2", "FALL", "N/A", [section3], [section4], None)
     filter = Filter(before_time = "08:00", day_of_week = DayOfWeek.MONDAY, after_time = "22:00")
@@ -75,8 +75,8 @@ def test_filter_all_courses():
     
 
 def test_filter():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], None)
     course.filter(Filter())
     assert course.lecture_sections == [section1, section2]
@@ -86,9 +86,9 @@ def test_filter():
         course.filter(None)
 
 def test_get_lecture_section():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section3 = Section("CODE2000", "A", "11113", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE2000", "A", "11113", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
 
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section3], [section2], None)
     assert course.get_lecture_section("A") == section1
@@ -96,9 +96,9 @@ def test_get_lecture_section():
     assert course.get_lecture_section("C") == None
 
 def test_get_lab_section():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
-    section3 = Section("CODE3000", "B", "22225", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [])
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "B", "22225", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1], [section2, section3], None)
     assert course.get_lab_section("A") == None
     assert course.get_lab_section("B") == section2

--- a/Backend/tests/unit/test_database.py
+++ b/Backend/tests/unit/test_database.py
@@ -45,7 +45,9 @@ test_scan_response2 = {
                 'TermDuration': {'S': 'Full Term'}, 
                 'AlsoRegister': {'L': []}, 
                 'SectionID': {'S': 'B'}, 
-                'CRN': {'S': '35905'}}}]}, 
+                'CRN': {'S': '35905'},
+                'StartDate': {'S': '2023-09-06'},
+                'EndDate': {'S': '2023-12-08'}}}]}, 
             'Subject': {'S': 'SYSC 4001'}
         } 
     ]

--- a/Backend/tests/unit/test_endpoints.py
+++ b/Backend/tests/unit/test_endpoints.py
@@ -12,7 +12,7 @@ from Backend.src.database.database import course_database as database
 from Backend.tests.unit.test_database import test_scan_response1 as response1, test_scan_response2 as response2
 
 TEST_TERM = "Fall 2023"
-SAMPLE_SCHEDULE = [[Section("SYSC 4001", "B", "35905", "Test Prof 2", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "08:35", "11:25")], "Registration Closed", []).to_dict()]]
+SAMPLE_SCHEDULE = [[Section("SYSC 4001", "B", "35905", "Test Prof 2", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "08:35", "11:25")], "Registration Closed", [], "2023-09-06", "2023-12-08").to_dict()]]
 
 @pytest.fixture()
 def empty_json_event():

--- a/Backend/tests/unit/test_scheduler.py
+++ b/Backend/tests/unit/test_scheduler.py
@@ -10,13 +10,13 @@ def test_is_section_schedulable():
     '''
     Tests that isSectionShedulable can handle overlaping classes and schedulable classes
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [])
-    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", [])
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
     schedule = [
-        Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.MONDAY, TermDuration.EARLY_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.EARLY_TERM, "09:05", "10:35") ], "", []),
-        Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.LATE_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.LATE_TERM, "10:05", "11:35") ], "", [])
+        Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.MONDAY, TermDuration.EARLY_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.EARLY_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08"),
+        Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.LATE_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.LATE_TERM, "10:05", "11:35") ], "", [], "2023-09-06", "2023-12-08")
     ]
     assert scheduler.is_section_schedulable(section1, schedule) == False
     assert scheduler.is_section_schedulable(section2, schedule) == False
@@ -25,13 +25,13 @@ def test_is_section_schedulable():
 
 
 def test_are_sections_schedulable():
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [])
-    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", [])
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
     schedule = [
-        Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", []),
-        Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "10:05", "11:35") ], "", [])
+        Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08"),
+        Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "10:05", "11:35") ], "", [], "2023-09-06", "2023-12-08")
     ]
     assert scheduler.are_sections_schedulable([section1, section2, section3, section4], schedule) == False
     assert scheduler.are_sections_schedulable([section4, section1], schedule) == False
@@ -39,20 +39,20 @@ def test_are_sections_schedulable():
     assert scheduler.are_sections_schedulable([section3, section4], schedule) == True
 
 def test_do_section_times_overlap():
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [])
-    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", [])
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
     assert scheduler.do_section_times_overlap([section1, section2]) == True
     assert scheduler.do_section_times_overlap([section1, section3, section4]) == False
     assert scheduler.do_section_times_overlap([section2, section3, section4]) == False
     assert scheduler.do_section_times_overlap([section1]) == False
 
 def test_get_related_section_combinations():
-    section1 = Section("CODE1000", "A", "11111", "Alice", [], "", [["B"], ["C", "D"]])
-    section2 = Section("CODE2000", "B", "22222", "Bob", [], "", [])
-    section3 = Section("CODE3000", "C", "33333", "Charlie", [], "", [])
-    section4 = Section("CODE3000", "D", "33333", "Charlie", [], "", [])
+    section1 = Section("CODE1000", "A", "11111", "Alice", [], "", [["B"], ["C", "D"]], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE2000", "B", "22222", "Bob", [], "", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "C", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE3000", "D", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
     course = Course("", "", "", "", [section1], [section2, section3, section4], "")
     assert scheduler.get_related_section_combinations(course, section1) == [[section2, section3], [section2, section4]]
 
@@ -82,8 +82,8 @@ def test_can_take_together():
     '''
     LECTURE_SECTION_ID = "A"
     LAB_SECTION_ID = "L01"
-    lecture_section = Section("CODE1234", LECTURE_SECTION_ID, "54321", "Jill", [], "", [[LAB_SECTION_ID]])
-    lab_section = Section("CODE1234", LAB_SECTION_ID, "54321", "Jill", [], "", [["Z", "Q"], [LECTURE_SECTION_ID]])
+    lecture_section = Section("CODE1234", LECTURE_SECTION_ID, "54321", "Jill", [], "", [[LAB_SECTION_ID]], "2023-09-06", "2023-12-08")
+    lab_section = Section("CODE1234", LAB_SECTION_ID, "54321", "Jill", [], "", [["Z", "Q"], [LECTURE_SECTION_ID]], "2023-09-06", "2023-12-08")
     assert scheduler.can_take_together(lecture_section, lab_section) == True
     lecture_section.related_section_ids.pop()
     assert scheduler.can_take_together(lecture_section, lab_section) == False
@@ -95,7 +95,7 @@ def test_generate_schedules_with_no_courses():
     Tests that generateSchedules function can handle empty courses list
     '''
     schedule = [
-        Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
+        Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
     ]
     assert scheduler.generate_schedules([], schedule) == [schedule]
 
@@ -104,11 +104,11 @@ def test_generate_schedules_with_lab_sections():
     '''
     Tests that the generateSchedules function can schedule courses with lab sections
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [["L1", "L2"]])
-    section2A = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["A"]])
-    section2B = Section("CODE1000", "L2", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", [["A"]])
-    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section4 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [])
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [["L1", "L2"]], "2023-09-06", "2023-12-08")
+    section2A = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["A"]], "2023-09-06", "2023-12-08")
+    section2B = Section("CODE1000", "L2", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", [["A"]], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [section2A, section2B], None)
     schedule1 = [
         section3, section4
@@ -126,9 +126,9 @@ def test_generate_schedules_without_lab_sections():
     '''
     Test that the generateSchedules function can schedule courses without lab section
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section2 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section3 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [])
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [], None)
     schedule1 = [
         section2, section3
@@ -144,9 +144,9 @@ def test_generate_schedules_with_incompatible_lab():
     '''
     Tests the generateSchedules function with incomptible lecture/lab sections
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [["A1"]])
-    section2 = Section("CODE1000", "A1", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["A"]])
-    section3 = Section("CODE1000", "B1", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["B"]])
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [["A1"]], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "A1", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["A"]], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE1000", "B1", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["B"]], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [section2, section3], None)
     expected_schedule = [
        section1, section2
@@ -158,10 +158,10 @@ def test_generate_schedules_with_unschedulable_section():
     '''
     Tests the generateSchedules function unschedulable lecture AND lab section
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [["L1"]])
-    section2 = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "13:55")], "", [["A"]])
-    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section4 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [])
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [["L1"]], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "13:55")], "", [["A"]], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [section2], None)
     course2 = Course("CODE4000", "TESTCLASS2", "Fall 2023", "NONE", [section3], [], None)
     schedule1 = [
@@ -174,13 +174,13 @@ def test_generate_schedules_with_lab_and_tutorials():
     '''
     Tests that the generateSchedules function can schedule courses with lab sections and tutorial sections
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["ETU"], ["L1", "L2"]])
-    section2A = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["A"]])
-    section2B = Section("CODE1000", "L2", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", [["A"]])
-    section2C = Section("CODE1000", "ETU", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "20:05", "21:35")], "", [["A"]])
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["ETU"], ["L1", "L2"]], "2023-09-06", "2023-12-08")
+    section2A = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["A"]], "2023-09-06", "2023-12-08")
+    section2B = Section("CODE1000", "L2", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", [["A"]], "2023-09-06", "2023-12-08")
+    section2C = Section("CODE1000", "ETU", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "20:05", "21:35")], "", [["A"]], "2023-09-06", "2023-12-08")
     
-    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [])
-    section4 = Section("CODE4000", "E", "55555", "Eric", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [])
+    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE4000", "E", "55555", "Eric", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [], "2023-09-06", "2023-12-08")
     
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [section2A, section2B, section2C], None)
     course2 = Course("CODE4000", "TESTCLASS", "Fall 2023", "NONE", [section3, section4], [], None)

--- a/Backend/tests/unit/test_section.py
+++ b/Backend/tests/unit/test_section.py
@@ -9,6 +9,8 @@ def test_to_dict():
     times = []
     status = "OPEN"
     related_sections = []
-    section = Section(course_code, section_id, crn, instructor, times, status, related_sections)
+    start_date = "2023-09-06"
+    end_date = "2023-12-08"
+    section = Section(course_code, section_id, crn, instructor, times, status, related_sections, start_date, end_date)
     assert section.to_dict() == {"CourseCode":course_code, "SectionID":section_id, "CRN":crn,
-                                 "Instructor":instructor, "Times":times, "Status":status}
+                                 "Instructor":instructor, "Times":times, "Status":status, "StartDate": start_date, "EndDate": end_date}

--- a/WebScraping/functions/createTable/lambda_function.py
+++ b/WebScraping/functions/createTable/lambda_function.py
@@ -15,7 +15,7 @@ def lambda_handler(event: dict, context: dict) -> str:
     - str: A message indicating that the DynamoDB table has been successfully created. 
     '''
     dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.create_table(TABLE_NAME,
+    table = dynamodb.create_table(TableName=TABLE_NAME,
             KeySchema=[
                 {
                     'AttributeName': 'Subject', 

--- a/WebScraping/tests/unit/test_create_db.py
+++ b/WebScraping/tests/unit/test_create_db.py
@@ -14,7 +14,7 @@ def test_lambda_handler():
 
         mock_resource.assert_called_with("dynamodb")
         mock_dynamodb.create_table.assert_called_with(
-            expected_table_name,
+            TableName=expected_table_name,
             KeySchema=[
                 {'AttributeName': 'Subject', 'KeyType': 'HASH'},
                 {'AttributeName': 'Term', 'KeyType': 'RANGE'}

--- a/WebScraping/tests/unit/test_parser.py
+++ b/WebScraping/tests/unit/test_parser.py
@@ -91,13 +91,15 @@ def test_parse_data(get_lecture_bs4_object, get_lab_bs4_object):
                 "CRN": "35659", 
                 "Status": "Registration Closed", 
                 "SectionType": "In person", 
-                "Instructor": "Test Professor", 
+                "Instructor": "Test Professor",
                 "MeetingDates": [
                     {"DayOfWeek": "Wed", "StartTime": "11:35", "EndTime": "12:55"}, 
                     {"DayOfWeek": "Fri", "StartTime": "11:35", "EndTime": "12:55"}
                 ], 
                 "TermDuration": "Full Term", 
-                "AlsoRegister": [["A1", "A2", "A3"]]
+                "AlsoRegister": [["A1", "A2", "A3"]],
+                "StartDate": "2023-09-06",
+                "EndDate": "2023-12-08"
             }],
             "LabSections": [{
                 "SectionID": "A1", 
@@ -110,6 +112,8 @@ def test_parse_data(get_lecture_bs4_object, get_lab_bs4_object):
                 ], 
                 "TermDuration": "Full Term",
                 "AlsoRegister": [["A"]],
+                "StartDate": "2023-09-06",
+                "EndDate": "2023-12-08",
                 "WeekSchedule": "Every Week"
             }]
         }
@@ -224,3 +228,17 @@ def test_get_meeting_date_list_edge_cases():
     expected_list = [{"DayOfWeek": "Wed", "StartTime": "11:35", "EndTime": "14:25"}, 
         {"DayOfWeek": "Fri", "StartTime": "11:35", "EndTime": "14:25"}]
     assert result2 == expected_list
+
+
+def test_get_formatted_term_dates():
+    test_term_date1 = "Sep 06, 2023 to Dec 08, 2023"
+    assert get_formatted_term_dates(test_term_date1) == ("2023-09-06", "2023-12-08")
+
+    test_term_date2 = "Jan 08, 2024 to Apr 10, 2024"
+    assert get_formatted_term_dates(test_term_date2) == ("2024-01-08", "2024-04-10")
+
+    test_term_date3 = "May 06, 2024 to Aug 14, 2024"
+    assert get_formatted_term_dates(test_term_date3) == ("2024-05-06", "2024-08-14")
+
+    assert get_formatted_term_dates("") == ("", "")
+    assert get_formatted_term_dates(None) == ("", "")


### PR DESCRIPTION
Inorder to display the correct weeks for a schedule on the frontend side the start and end dates are required. These dates were added to the section json of a class (lecture or lab) with the following format: yyyy-mm-dd (needed by full calendar). In addtion a fix for the create db function is a part of this pr (was pushed to the branch)