### PR TITLE
Fixed frontend bug where different classes were the same colour

### DIFF
--- a/Frontend/src/common/utils.js
+++ b/Frontend/src/common/utils.js
@@ -155,16 +155,16 @@ const assignColoursToEvents = (events, colours) => {
         return matches ? matches[1] : title;
     };
 
-    colours.forEach((colour, idx) => {
-        const title = events[idx % events.length].title;
-        const commonPrefix = getPrefix(title);
-        colourMapping[commonPrefix] = colour;
-    });
-
+    let colourIndex = 0;
     events.forEach(event => {
         const commonPrefix = getPrefix(event.title);
         if (colourMapping.hasOwnProperty(commonPrefix)) {
             event.color = colourMapping[commonPrefix];
+        }
+        else {
+            event.color = colours[colourIndex]
+            colourMapping[commonPrefix] = event.color;
+            colourIndex += 1;
         }
     });
 }


### PR DESCRIPTION
Fixed frontend bug where events of different classes were the same colour. This was caused when building a schedule that has more than 9 events (e.g. 5 courses with 2 classes per week = 10 events). The previous code only assigned colours to the first 9 events, and any additional events were left with the default colour.