### PR TITLE
Added code to backend to filter between times

### DIFF
--- a/Backend/src/endpoints.py
+++ b/Backend/src/endpoints.py
@@ -4,6 +4,8 @@ from .database.database_type import course_database
 from .model.course import Course
 from .model.date import ClassTime
 from .model.day_of_week import DayOfWeek
+from .model.term_duration import TermDuration
+from .model.week_schedule import WeekSchedule
 from .model.filter import Filter
 from .scheduler import generate_schedules, MAX_SCHEDULES
 from .logger import logger
@@ -100,15 +102,19 @@ def filter_inputted_courses(request_body: dict, inputted_courses: List[Course]) 
         before_time_input = filters_object.get("BeforeTime")
         after_time_input = filters_object.get("AfterTime")
         day_input = filters_object.get("DayOfWeek")
+        between_times_input = filters_object.get("BetweenTimes")
         try:
             day_of_week = None
+            between_times = []
             if before_time_input is not None:
                 ClassTime.convert_time_to_float(before_time_input)
             if after_time_input is not None:
                 ClassTime.convert_time_to_float(after_time_input)
             if day_input is not None:
                 day_of_week = DayOfWeek(day_input)
-            class_filter = Filter(before_time=before_time_input, after_time=after_time_input, day_of_week=day_of_week)
+            if between_times_input is not None:
+                between_times = [convert_to_classtime(between_time) for between_time in between_times_input]
+            class_filter = Filter(before_time=before_time_input, after_time=after_time_input, day_of_week=day_of_week, between_times=between_times)
             Course.filter_all_courses(inputted_courses, class_filter)
         except:
             error_message = f"One or more of the filters are formatted incorrectly!"
@@ -116,3 +122,17 @@ def filter_inputted_courses(request_body: dict, inputted_courses: List[Course]) 
             raise Exception(error_message)
     else:
         Course.filter_all_courses(inputted_courses, Filter())
+
+def convert_to_classtime(between_time: dict) -> ClassTime:
+    '''
+    Helper function to convert a time sent in a request to a ClassTime object
+    '''
+    try:
+        day_of_week = DayOfWeek(between_time.get("DayOfWeek"))
+        start_time = between_time.get("StartTime")
+        end_time = between_time.get("EndTime")
+        return ClassTime(day_of_week, TermDuration.FULL_TERM, start_time, end_time, WeekSchedule.EVERY_WEEK)
+    except:
+        error_message = f"The BetweenTimes filters are formatted incorrectly!"
+        logger.error(error_message)
+        raise Exception(error_message)

--- a/Backend/src/model/course.py
+++ b/Backend/src/model/course.py
@@ -51,6 +51,9 @@ class Course:
 
         if filter.day_of_week:
             self.filter_day_off(filter.day_of_week)
+
+        if filter.between_times:
+            self.filter_between_times(filter.between_times)
         
         if self.section_id_filter:
             self.filter_by_section()
@@ -96,6 +99,20 @@ class Course:
 
         Course.time_filter(self.lecture_sections, compare_function)
         Course.time_filter(self.lab_sections, compare_function)
+
+    def filter_between_times(self, between_times: List[ClassTime]) -> None:
+        '''
+        Filter out all sections that take place between a list of times
+        '''
+        if not isinstance(between_times, list):
+            raise TypeError("Parameter 'between_times' must be of type list")
+        
+        for between_time in between_times:
+            def compare_function(date: ClassTime):
+                return date.does_date_overlap(between_time)
+
+            Course.time_filter(self.lecture_sections, compare_function)
+            Course.time_filter(self.lab_sections, compare_function) 
 
     def filter_by_section(self):
         if not isinstance(self.section_id_filter, str):

--- a/Backend/src/model/filter.py
+++ b/Backend/src/model/filter.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
+from typing import List
 from .day_of_week import DayOfWeek
+from .date import ClassTime
 
 
 class Filter:
     before_time: str = None
     after_time: str = None
     day_of_week: DayOfWeek = None
+    between_times: List[ClassTime] = []
 
     def __init__(self, **kwargs):
         if kwargs.get('before_time') and not isinstance(kwargs.get('before_time'), str):
@@ -14,8 +17,13 @@ class Filter:
             raise TypeError("after_time must be of type str")
         if kwargs.get('day_of_week') and not isinstance(kwargs.get('day_of_week'), DayOfWeek):
             raise TypeError("day_of_week must be of type DayOfWeek")
+        if kwargs.get('between_times') and not isinstance(kwargs.get('between_times'), list):
+            raise TypeError("between_times must be of type list")
+        if kwargs.get('between_times') and any(not isinstance(between_time, ClassTime) for between_time in kwargs.get('between_times')):
+            raise TypeError("between_times cannot contain objects of type other than ClassTime")
 
         self.before_time = kwargs.get('before_time', None)
         self.after_time = kwargs.get('after_time', None)
         self.day_of_week = kwargs.get('day_of_week', None)
+        self.between_times = kwargs.get('between_times', [])
 

--- a/Backend/tests/unit/test_course.py
+++ b/Backend/tests/unit/test_course.py
@@ -42,6 +42,17 @@ def test_filter_day_off():
     with pytest.raises(TypeError):
         course.filter_day_off("MONDAY")
 
+def test_filter_between_times():
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", [], "2023-09-06", "2023-12-08") 
+    course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
+
+    course.filter_between_times([ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "06:00", "09:30"), ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "17:00", "19:00")])
+    assert course.lecture_sections == []
+
+    #test error case
+    with pytest.raises(TypeError):
+        course.filter_between_times("Mon-Fri")
 
 def test_filter_by_section():
     section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
@@ -63,7 +74,7 @@ def test_filter_all_courses():
     section4 = Section("CODE2000", "B", "22222", "JON", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
     course2 = Course("CODE2000", "CLASS NAME 2", "FALL", "N/A", [section3], [section4], None)
-    filter = Filter(before_time = "08:00", day_of_week = DayOfWeek.MONDAY, after_time = "22:00")
+    filter = Filter(before_time = "08:00", day_of_week = DayOfWeek.MONDAY, after_time = "22:00", between_times=[ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "18:00", "23:00")])
     Course.filter_all_courses([course1, course2], filter)
     assert course1.lecture_sections == [section2]
     assert course2.lecture_sections == []

--- a/Backend/tests/unit/test_endpoints.py
+++ b/Backend/tests/unit/test_endpoints.py
@@ -35,7 +35,7 @@ def generate_schedules_event():
 @pytest.fixture()
 def generate_schedules_with_filters_event():
     return {
-        "body": f"{{\"Term\": \"{TEST_TERM}\", \"Filters\": {{\"BeforeTime\": \"08:00\", \"AfterTime\": \"19:00\", \"DayOfWeek\":\"Tue\"}}, \"Courses\": [{{\"SectionFilter\":\"B\", \"Name\":\"SYSC 4001\"}}]}}"
+        "body": f"{{\"Term\": \"{TEST_TERM}\", \"Filters\": {{\"BeforeTime\": \"08:00\", \"AfterTime\": \"19:00\", \"DayOfWeek\":\"Tue\", \"BetweenTimes\": [{{\"DayOfWeek\":\"Fri\", \"StartTime\":\"11:00\", \"EndTime\":\"15:00\"}}]}}, \"Courses\": [{{\"SectionFilter\":\"B\", \"Name\":\"SYSC 4001\"}}]}}"
     }
 
 @pytest.fixture()
@@ -210,3 +210,12 @@ def test_get_courses(get_courses_event):
     assert data["Error"] == False
     assert data["ErrorReason"] == ""
     assert data["Courses"] == ['ARCH 4505', 'ARCH 4505 A', 'SYSC 4001', 'SYSC 4001 B']
+
+def test_convert_to_classtime():
+    classtime = endpoints.convert_to_classtime({"DayOfWeek":"Mon", "StartTime":"11:00", "EndTime":"15:00"})
+    assert classtime.day == DayOfWeek.MONDAY
+    assert classtime.start_time == "11:00"
+    assert classtime.end_time == "15:00"
+
+    with pytest.raises(Exception):
+        endpoints.convert_to_classtime({"DayOfWeek":[], "StartTime":"11:00", "EndTime":"15:00"})

--- a/Backend/tests/unit/test_filter.py
+++ b/Backend/tests/unit/test_filter.py
@@ -1,18 +1,23 @@
 import pytest
 from Backend.src.model.filter import Filter
 from Backend.src.model.day_of_week import DayOfWeek
+from Backend.src.model.term_duration import TermDuration
+from Backend.src.model.date import ClassTime
 
 def test_create_empty_filter():
     filter = Filter()
     assert filter.before_time == None
     assert filter.after_time == None
     assert filter.day_of_week == None
+    assert filter.between_times == []
 
 def test_create_filter():
-    filter = Filter(before_time = "09:00", after_time = "14:00", day_of_week = DayOfWeek.MONDAY)
+    classtime = ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "10:00", "14:00")
+    filter = Filter(before_time = "09:00", after_time = "14:00", day_of_week = DayOfWeek.MONDAY, between_times=[classtime])
     assert filter.before_time == "09:00"
     assert filter.after_time == "14:00"
     assert filter.day_of_week == DayOfWeek.MONDAY
+    assert filter.between_times == [classtime]
 
 def test_invalid_before_time():
     with pytest.raises(TypeError):
@@ -25,3 +30,9 @@ def test_invalid_after_time():
 def test_invalid_day_of_week():
     with pytest.raises(TypeError):
         Filter(day_of_week = "MONDAY")
+
+def test_invalid_between_times():
+    with pytest.raises(TypeError):
+        Filter(between_times = "MONDAY")
+    with pytest.raises(TypeError):
+        Filter(between_times = ["MONDAY"])


### PR DESCRIPTION
Added code to backend to filter between times (in the filters, you can include a list of times where you don't want classes e.g.: Filters: { "BetweenTimes": [ {"DayOfWeek": "Fri", "StartTime": "11:00", "EndTime": "14:00"} ] } ). Note that start and end times are non-inclusive, so that means a class could be scheduled on Friday from 14:00-15:35 and it would not be filtered out (I think this makes sense personally). This feature can now be implemented on the frontend.