### PR TITLE
Added reading week dates as a part of the terms courses file

### DIFF
--- a/.github/workflows/webscraping-pipeline.yml
+++ b/.github/workflows/webscraping-pipeline.yml
@@ -8,6 +8,7 @@ on:
         - WebScraping/functions/insertData/**
         - WebScraping/functions/createTable/**
         - WebScraping/functions/createTermsCoursesJson/**
+        - WebScraping/functions/getReadingWeekDates/**
 jobs:
     build-deploy:
       runs-on: ubuntu-latest

--- a/Backend/src/database/database.py
+++ b/Backend/src/database/database.py
@@ -43,9 +43,9 @@ class CourseDatabase(ABC):
         '''
 
     @abstractmethod
-    def get_terms(self) -> List[str]:
+    def get_terms(self) -> List[str] | dict:
         '''
-        Gets the list of terms in the database.
+        Gets the dict or list of terms from the database.
         '''
     
     @abstractmethod

--- a/Backend/src/database/s3_database.py
+++ b/Backend/src/database/s3_database.py
@@ -51,8 +51,8 @@ class S3Database(CourseDatabase):
         Gets the terms dict in the database.
         '''
         terms_course_copy = self.terms_courses_dict.copy()
-        for term_dict in terms_course_copy:
-            terms_course_copy.get(term_dict, {}).pop("Classes", None)
+        for term in terms_course_copy:
+            terms_course_copy.get(term, {}).pop("Classes", None)
 
         return terms_course_copy
 

--- a/Backend/src/database/s3_database.py
+++ b/Backend/src/database/s3_database.py
@@ -46,15 +46,19 @@ class S3Database(CourseDatabase):
         
         return self.convert_to_course(course_map)
 
-    def get_terms(self) -> List[str]:
+    def get_terms(self) -> dict:
         '''
-        Gets the list of terms in the database.
+        Gets the terms dict in the database.
         '''
-        return list(self.terms_courses_dict.keys())
+        terms_course_copy = self.terms_courses_dict.copy()
+        for term_dict in terms_course_copy:
+            terms_course_copy.get(term_dict, {}).pop("Classes", None)
+
+        return terms_course_copy
 
 
     def get_course_code_and_section_list(self, term: str) -> List[str]:
         '''
         Gets a list of the course codes and sections for a given term.
         '''
-        return self.terms_courses_dict.get(term, [])
+        return self.terms_courses_dict.get(term, {}).get("Classes", [])

--- a/Backend/src/database/s3_database.py
+++ b/Backend/src/database/s3_database.py
@@ -51,8 +51,8 @@ class S3Database(CourseDatabase):
         Gets the terms dict in the database.
         '''
         terms_course_copy = self.terms_courses_dict.copy()
-        for term in terms_course_copy:
-            terms_course_copy.get(term, {}).pop("Classes", None)
+        for term_dict in terms_course_copy.values():
+            term_dict.pop("Classes", None)
 
         return terms_course_copy
 

--- a/Backend/tests/unit/test_s3_database.py
+++ b/Backend/tests/unit/test_s3_database.py
@@ -16,7 +16,14 @@ CLASSES_DICT = {"AERO 2001-Fall 2023": {
                        "TermDuration": "Full Term", "AlsoRegister": [["A"]], "StartDate": "2023-09-06", "EndDate": "2023-12-08", "WeekSchedule": "Every Week"}]
   }, "ERRORCLASS": {}
 }
-TERMS_COURSES_DICT = {"Fall 2023": ["AERO 2001", "AERO 2001 A"]}
+TERMS_COURSES_DICT = {
+    "Fall 2023": {
+        "Classes": ["AERO 2001", "AERO 2001 A"],
+        "ReadingWeekStart": "2023-10-20", 
+        "ReadingWeekEnd": "2023-10-30", 
+        "ReadingWeekNext": "2023-11-06"
+    }
+}
 
 @patch('boto3.resource')
 @patch('json.load')
@@ -48,7 +55,14 @@ def test_get_course_code_and_section_list():
 
 def test_get_terms():
     db = generate_db()
-    assert db.get_terms() == [test_term]
+    expected_dict = {
+    "Fall 2023": {
+        "ReadingWeekStart": "2023-10-20", 
+        "ReadingWeekEnd": "2023-10-30", 
+        "ReadingWeekNext": "2023-11-06"
+        }
+    }
+    assert db.get_terms() == expected_dict
     
     
 def test_get_course():

--- a/Frontend/src/common/APIutils.js
+++ b/Frontend/src/common/APIutils.js
@@ -26,7 +26,7 @@ export const fetchCourses = async (term) => {
     }
 }
 
-export const fetchSchedules = async (inputs) => {
+export const fetchSchedules = async (inputs, readingWeekDates) => {
     try {
         const formattedRequest = parseInputs(inputs);
         const response = await axios.post(SCHEDULES_URL, formattedRequest);
@@ -42,7 +42,7 @@ export const fetchSchedules = async (inputs) => {
             allAsyncCoursesError.name = ALL_ASYNC_COURSES_ERROR;
             throw allAsyncCoursesError;
         } else {
-            return parseScheduleIntoEvents(response.data.Schedules, inputs.term);
+            return parseScheduleIntoEvents(response.data.Schedules, inputs.term, readingWeekDates);
         }
     } catch (error) {
         throw error;

--- a/Frontend/src/common/utils.js
+++ b/Frontend/src/common/utils.js
@@ -1,5 +1,4 @@
 // Formatting functions 
-import { fetchTerms } from './APIutils';
 
 export const parseInputs = (inputs) => {
     const courses = [
@@ -36,11 +35,9 @@ export const parseInputs = (inputs) => {
 }
 
 
-export const parseScheduleIntoEvents = async (schedules, term) => {
+export const parseScheduleIntoEvents = (schedules, term, readingWeekDates) => {
     const events = [];
     const asyncEvents = [];
-    const termsResults = await fetchTerms();
-    const readingWeekDates = termsResults.Terms;
     schedules.forEach(schedule => {
         const eventsForCurrentSchedule = [];
         const asyncCoursesForCurrentSchedule = [];

--- a/Frontend/src/common/utils.js
+++ b/Frontend/src/common/utils.js
@@ -1,4 +1,5 @@
 // Formatting functions 
+import { fetchTerms } from './APIutils';
 
 export const parseInputs = (inputs) => {
     const courses = [
@@ -34,27 +35,12 @@ export const parseInputs = (inputs) => {
     return JSON.stringify(requestFormat, null, 5);
 }
 
-const READING_WEEK = {
-    "Fall 2023": {
-        "start": "2023-10-20",  //Last Friday before classes start
-        "end": "2023-10-30",    //First day back from reading week when classes resume
-        "nextEnd": "2023-11-06" //2nd week back from reading week (for E/O labs)
-    },
-    "Winter 2024": {
-        "start": "2024-02-16",
-        "end": "2024-02-26",
-        "nextEnd": "2024-03-04"
-    },
-    "Summer 2024": {
-        "start": "2024-06-18",
-        "end": "2024-07-02",
-        "nextEnd": "2024-07-08" //Don't think summer has E/O labs
-    }
-}
 
-export const parseScheduleIntoEvents = (schedules, term) => {
+export const parseScheduleIntoEvents = async (schedules, term) => {
     const events = [];
     const asyncEvents = [];
+    const termsResults = await fetchTerms();
+    const readingWeekDates = termsResults.Terms;
     schedules.forEach(schedule => {
         const eventsForCurrentSchedule = [];
         const asyncCoursesForCurrentSchedule = [];
@@ -75,19 +61,19 @@ export const parseScheduleIntoEvents = (schedules, term) => {
                             freq: "weekly",
                             interval: 2,
                             dtstart: `${startDate}T${time.StartTime}:00`,
-                            until: READING_WEEK[term]["start"],//`${updatedEndDateStr}`,
+                            until: readingWeekDates[term]["start"],//`${updatedEndDateStr}`,
                             byweekday: [convertDayToInt(time.DayOfWeek) - 1],
                         },
                         duration: calculateTimeDifference(time.StartTime, time.EndTime),
                     };
                     eventsForCurrentSchedule.push(biWeeklyEvent);
 
-                    const parity = getParity(startDate, READING_WEEK[term]["start"], time.WeekSchedule);
+                    const parity = getParity(startDate, readingWeekDates[term]["start"], time.WeekSchedule);
                     let updatedStartDate;
                     if (parity === "Odd Week" && time.WeekSchedule === "Odd Week") {
-                        updatedStartDate = READING_WEEK[term]["end"]
+                        updatedStartDate = readingWeekDates[term]["end"]
                     } else {
-                        updatedStartDate = READING_WEEK[term]["nextEnd"]
+                        updatedStartDate = readingWeekDates[term]["nextEnd"]
                     }
 
                     const biWeeklyEvent2 = {
@@ -114,7 +100,7 @@ export const parseScheduleIntoEvents = (schedules, term) => {
                         endTime: `${time.EndTime}:00`,
                         daysOfWeek: [convertDayToInt(time.DayOfWeek)],
                         startRecur: startDate,
-                        endRecur: READING_WEEK[term]["start"]
+                        endRecur: readingWeekDates[term]["start"]
                     }
                     eventsForCurrentSchedule.push(event);
                     // This event spans from after reading week to end of term
@@ -123,7 +109,7 @@ export const parseScheduleIntoEvents = (schedules, term) => {
                         startTime: `${time.StartTime}:00`,
                         endTime: `${time.EndTime}:00`,
                         daysOfWeek: [convertDayToInt(time.DayOfWeek)],
-                        startRecur: READING_WEEK[term]["end"],
+                        startRecur: readingWeekDates[term]["end"],
                         endRecur: updatedEndDateStr // exclusive so has to be +1
                     };
                     eventsForCurrentSchedule.push(event2)

--- a/Frontend/src/components/FormComponent.js
+++ b/Frontend/src/components/FormComponent.js
@@ -45,7 +45,6 @@ const FormComponent = () => {
                             ...prev,
                             [term]: result.Courses || [],
                         }));
-                        console.log(readingWeekList)
                     }
                 }).catch((error) => {
                     console.error("Error getting courses: ", error.message)
@@ -56,7 +55,7 @@ const FormComponent = () => {
             getAllCourses(term);
         });
 
-    }, [termsList]);
+    }, [termsList, readingWeekList]);
 
     useEffect(() => {
         fetchTerms()
@@ -66,12 +65,11 @@ const FormComponent = () => {
                 } else {
                     setTermsList(Object.keys(result.Terms));
                     setReadingWeekList(result.Terms);
-                    console.log(readingWeekList);
                 }
             }).catch((error) => {
                 console.error("Error getting terms: ", error.message);
             })
-    }, []);
+    }, [readingWeekList]);
 
     //This is to check that user didn't leave all courses blank
     useEffect(() => {

--- a/Frontend/src/components/FormComponent.js
+++ b/Frontend/src/components/FormComponent.js
@@ -62,7 +62,7 @@ const FormComponent = () => {
                 if (result.Error) {
                     console.log("Failed to get terms: ", result.ErrorReason);
                 } else {
-                    setTermsList(result.Terms);
+                    setTermsList(Object.keys(result.Terms));
                 }
             }).catch((error) => {
                 console.error("Error getting terms: ", error.message);

--- a/Frontend/src/components/FormComponent.js
+++ b/Frontend/src/components/FormComponent.js
@@ -32,6 +32,7 @@ const FormComponent = () => {
     const [nonEmptyCoursesCount, setNoneEmptyCoursesCount] = useState(0);
     const [termsList, setTermsList] = useState([]);
     const [coursesList, setCoursesList] = useState({});
+    const [readingWeekList, setReadingWeekList] = useState({});
 
     useEffect(() => {
         const getAllCourses = async (term) => {
@@ -44,6 +45,7 @@ const FormComponent = () => {
                             ...prev,
                             [term]: result.Courses || [],
                         }));
+                        console.log(readingWeekList)
                     }
                 }).catch((error) => {
                     console.error("Error getting courses: ", error.message)
@@ -63,6 +65,8 @@ const FormComponent = () => {
                     console.log("Failed to get terms: ", result.ErrorReason);
                 } else {
                     setTermsList(Object.keys(result.Terms));
+                    setReadingWeekList(result.Terms);
+                    console.log(readingWeekList);
                 }
             }).catch((error) => {
                 console.error("Error getting terms: ", error.message);
@@ -130,7 +134,7 @@ const FormComponent = () => {
         );
 
         if (isValidSubmission && nonEmptyCoursesCount > 0) {
-            fetchSchedules(inputValues).then((classes) => {
+            fetchSchedules(inputValues, readingWeekList).then((classes) => {
                 setEvents(classes[0]);
                 setAsyncEvents(classes[1])
                 setIsFormSubmitted(true);

--- a/WebScraping/functions/createTermsCoursesJson/lambda_function.py
+++ b/WebScraping/functions/createTermsCoursesJson/lambda_function.py
@@ -6,6 +6,7 @@ BUCKET_NAME = "carletonschedulingtool"
 KEY_PATH = "web-scraping-stepfunction/"
 CLASSES_FILENAME = "classes.json"
 TERMS_COURSES_FILENAME = "terms_courses.json"
+CLASSES_KEY = "Classes"
 
 def lambda_handler(event: dict, context: dict) -> str:
     terms_courses_dict = {}
@@ -14,10 +15,10 @@ def lambda_handler(event: dict, context: dict) -> str:
     for course in classes_list:
         subject = course["Subject"]
         term_key = course["Term"]
-        terms_courses_dict.setdefault(term_key, []).append(subject)
+        terms_courses_dict.setdefault(term_key, {}).setdefault(CLASSES_KEY, []).append(subject)
         
         for lecture in course["LectureSections"]:
-            terms_courses_dict.get(term_key).append(f"{subject} {lecture['SectionID']}")
+            terms_courses_dict.get(term_key).get(CLASSES_KEY).append(f"{subject} {lecture['SectionID']}")
 
     return write_terms_courses_to_s3(terms_courses_dict)
             

--- a/WebScraping/functions/getReadingWeekDates/lambda_function.py
+++ b/WebScraping/functions/getReadingWeekDates/lambda_function.py
@@ -1,0 +1,140 @@
+import json
+import boto3
+from datetime import datetime, timedelta
+import urllib3
+from bs4 import BeautifulSoup
+from typing import Tuple
+
+BASE_URL = "https://calendar.carleton.ca/academicyear"
+HTTP = urllib3.PoolManager()
+BUCKET_NAME = "carletonschedulingtool"
+KEY_PATH = "web-scraping-stepfunction/terms_courses.json"
+
+def lambda_handler(event: dict, context: dict) -> str:
+    parser = get_parser()
+    terms_courses_dict = get_terms_courses_dict()
+    
+    for term in terms_courses_dict.keys():
+        name, year = term.split()
+        term_search_str = f"{name.upper()} TERM {year}"
+        term_tbody = parser.find("td", string=term_search_str).find_parent("tbody")
+
+        if name == "Fall" or name == "Winter":
+            break_lookup_str = f"{name} break"
+            date = term_tbody.find(lambda tag: tag.name == "td" and break_lookup_str in tag.text).find_previous('td').text.strip()
+            
+            start_week, end_week, next_week = get_formatted_fall_or_winter_dates(date)
+
+        else:
+            start_lookup_str ="Last day of early summer classes"
+            start_date = term_tbody.find(lambda tag: tag.name == "td" and start_lookup_str in tag.text).find_previous('td').text.strip()
+            
+            end_lookup_str = "Late summer classes begin"
+            end_date = term_tbody.find(lambda tag: tag.name == "td" and end_lookup_str in tag.text).find_previous('td').text.strip()
+            
+            start_week, end_week, next_week = get_formatted_summer_dates(start_date, end_date)
+
+
+        terms_courses_dict[term]["ReadingWeekStart"] = start_week
+        terms_courses_dict[term]["ReadingWeekEnd"] = end_week
+        terms_courses_dict[term]["ReadingWeekNext"] = next_week
+        
+    return write_terms_courses_to_s3(terms_courses_dict)
+
+
+def get_parser() -> BeautifulSoup:
+    '''
+    Gets the bs4 html parser.
+
+    Returns:
+    BeautifulSoup: html parser object.
+    '''
+    req = HTTP.request("GET", BASE_URL)
+    html = req.data.decode("utf-8")
+    return BeautifulSoup(html, "html.parser")
+
+
+def get_terms_courses_s3_object() -> object:
+    '''
+    Gets the terms courses s3 file object.
+
+    Returns:
+    S3 Object: The s3 file object.
+    '''
+    s3 = boto3.resource("s3")
+    return s3.Object(BUCKET_NAME, KEY_PATH)
+    
+
+def get_terms_courses_dict() -> dict:
+    '''
+    Gets the list of classes from s3.
+    
+    Returns:
+    dict: terms course dict.
+    '''
+    terms_courses_file = get_terms_courses_s3_object()
+    return json.load(terms_courses_file.get()["Body"])
+
+
+def get_formatted_fall_or_winter_dates(date_str: str) -> Tuple[str, str, str]:
+    '''
+    Formats fall or winter term reading week dates. 
+
+    Parameters:
+    date_str: The string of the data that is to be formattted.
+
+    Returns:
+    Tuple: the formatted date start, end and next dates.
+    '''
+    month_str, start_end_str, year_str = date_str.split()
+    month = datetime.strptime(month_str, '%B').month
+    start_day = int(start_end_str.split('-')[0])
+    end_day = int(start_end_str.split('-')[1][:-1])
+    year = int(year_str)
+
+    start_date = (datetime(year, month, start_day) + timedelta(days=-3)).date().isoformat() 
+    end_date =(datetime(year, month, end_day) + timedelta(days=3)).date().isoformat() 
+    next_date = (datetime(year, month, end_day) + timedelta(days=10)).date().isoformat() 
+
+    return start_date, end_date, next_date
+
+
+def get_formatted_summer_dates(start_date: str, end_date: str) -> Tuple[str, str, str]:
+    '''
+    Formats the summer term reading week dates. 
+
+    Parameters:
+    start_date: The string start date that is to be formattted
+    start_date: The string end date that is to be formattted
+
+    Returns:
+    Tuple: the formatted date start, end and next dates.
+    '''
+    parsed_format = "%B %d, %Y"
+    formatted_format = "%Y-%m-%d"
+
+    parsed_start_date = datetime.strptime(start_date, parsed_format)
+    formatted_start_date = parsed_start_date.strftime(formatted_format)
+
+    parsed_end_date = datetime.strptime(end_date, parsed_format)
+    formatted_end_date = parsed_end_date.strftime(formatted_format)
+
+    return formatted_start_date, formatted_end_date, formatted_end_date
+
+
+def write_terms_courses_to_s3(updated_terms_courses: dict[str, str]) -> str:
+    '''
+    Writes updated terms courses file to S3.
+
+    Parameters: 
+    updated_terms_courses: dictionary of containing terms with courses and reading week dates.
+
+    Returns:
+    str: Message indicating the terms and courses file has been updated.
+    '''
+    terms_courses_file = get_terms_courses_s3_object()
+    terms_courses_file.put(Body=(bytes(json.dumps(updated_terms_courses).encode("UTF-8"))))
+    
+    return {
+        "Response": json.dumps("Reading week dates added to Terms and Course file!")
+    }

--- a/WebScraping/functions/getReadingWeekDates/lambda_function.py
+++ b/WebScraping/functions/getReadingWeekDates/lambda_function.py
@@ -92,7 +92,7 @@ def get_formatted_fall_or_winter_dates(date_str: str) -> Tuple[str, str, str]:
     end_day = int(start_end_str.split('-')[1][:-1])
     year = int(year_str)
 
-    start_date = (datetime(year, month, start_day) + timedelta(days=-3)).date().isoformat() 
+    start_date = (datetime(year, month, start_day) + timedelta(days=-2)).date().isoformat() 
     end_date =(datetime(year, month, end_day) + timedelta(days=3)).date().isoformat() 
     next_date = (datetime(year, month, end_day) + timedelta(days=10)).date().isoformat() 
 

--- a/WebScraping/tests/unit/test_create_terms_courses_json.py
+++ b/WebScraping/tests/unit/test_create_terms_courses_json.py
@@ -32,7 +32,7 @@ def test_lambda_handler():
         with patch(f"{FILE_PATH}.write_terms_courses_to_s3") as mock_write_terms:
             lambda_handler(event=None, context=None)
 
-            expected_result = {"Fall 2023": ["AERO 2001", "AERO 2001 A"]}
+            expected_result = {"Fall 2023": {"Classes": ["AERO 2001", "AERO 2001 A"]}}
             mock_write_terms.assert_called_once_with(expected_result)
 
 

--- a/WebScraping/tests/unit/test_get_reading_week_dates.py
+++ b/WebScraping/tests/unit/test_get_reading_week_dates.py
@@ -19,7 +19,7 @@ TERMS_COURSES_DICT = {
 UPDATED_TERMS_COURSES_DICT = {
     "Fall 2023": {
         "Classes": ["SYSC 4001", "SYSC 4001 A"],
-        "ReadingWeekStart": "2023-10-20", 
+        "ReadingWeekStart": "2023-10-21", 
         "ReadingWeekEnd": "2023-10-30", 
         "ReadingWeekNext": "2023-11-06"
     }
@@ -119,11 +119,11 @@ def test_get_terms_courses_dict():
 
 def test_get_formatted_fall_or_winter_dates():
     results = get_formatted_fall_or_winter_dates("October 23-27, 2023")
-    expected_dates = ("2023-10-20", "2023-10-30", "2023-11-06")
+    expected_dates = ("2023-10-21", "2023-10-30", "2023-11-06")
     assert results == expected_dates
 
     results = get_formatted_fall_or_winter_dates("February 19-23, 2024")
-    expected_dates = ("2024-02-16", "2024-02-26", "2024-03-04")
+    expected_dates = ("2024-02-17", "2024-02-26", "2024-03-04")
     assert results == expected_dates
 
 

--- a/WebScraping/tests/unit/test_get_reading_week_dates.py
+++ b/WebScraping/tests/unit/test_get_reading_week_dates.py
@@ -1,0 +1,148 @@
+from WebScraping.functions.getReadingWeekDates.lambda_function import *
+from unittest.mock import MagicMock, patch
+from botocore.stub import Stubber
+
+FILE_PATH = "WebScraping.functions.getReadingWeekDates.lambda_function"
+
+TERMS_COURSES_DICT = {
+    "Fall 2023": {
+        "Classes": ["SYSC 4001", "SYSC 4001 A"]
+    },
+    "Winter 2024": {
+        "Classes": ["SYSC 3200", "SYSC 3200 A"]
+    },
+    "Summer 2024": {
+        "Classes": ["SYSC 2006", "SYSC 2006 A"]
+    }
+}
+
+UPDATED_TERMS_COURSES_DICT = {
+    "Fall 2023": {
+        "Classes": ["SYSC 4001", "SYSC 4001 A"],
+        "ReadingWeekStart": "2023-10-20", 
+        "ReadingWeekEnd": "2023-10-30", 
+        "ReadingWeekNext": "2023-11-06"
+    }
+}
+
+MOCK_HTML = """
+    <tbody>
+        <tr class="even firstrow">
+            <td class="column0">FALL TERM 2023</td> 
+            <td class="column1"></td> 
+        </tr>
+        <tr class="odd">
+            <td class="column0">October 23-27, 2023</td> 
+            <td class="column1">Fall break, no classes.</td> 
+        </tr>
+    </tbody>
+    <tbody>
+        <tr class="even firstrow">
+            <td class="column0">WINTER TERM 2024</td> 
+            <td class="column1"></td> 
+        </tr>
+        <tr class="odd">
+            <td class="column0">February 19-23, 2024</td> 
+            <td class="column1">Winter break, no classes. </td> 
+        </tr>
+    </tbody>
+    <tbody>
+        <tr class="even firstrow">
+            <td class="column0">SUMMER TERM 2024</td> 
+            <td class="column1"></td> 
+        </tr>
+        <tr class="odd">
+            <td class="column0">June 18, 2024</td> 
+            <td class="column1">Last day of early summer classes. (NOTE: full summer classes resume July 2.)</td> 
+        </tr>
+        <tr class="odd">
+            <td class="column0">July 2, 2024</td> 
+            <td class="column1">Late summer classes begin and full summer classes resume. </td> 
+        </tr>
+    </tbody>
+"""
+
+def test_lambda_handler():
+    with patch(f'{FILE_PATH}.get_parser') as mock_get_parser, \
+         patch(f'{FILE_PATH}.get_terms_courses_dict') as mock_get_terms_courses_dict, \
+         patch(f'{FILE_PATH}.write_terms_courses_to_s3') as mock_write_terms_courses_to_s3:
+        
+        mock_get_parser.return_value = BeautifulSoup(MOCK_HTML, "html.parser")
+        mock_get_terms_courses_dict.return_value = TERMS_COURSES_DICT
+        mock_write_terms_courses_to_s3.return_value = {"Response": json.dumps("Reading week dates added to Terms and Course file!")}
+
+        lambda_handler({}, {})
+
+        mock_get_parser.assert_called_once()
+        mock_get_terms_courses_dict.assert_called_once()
+        mock_write_terms_courses_to_s3.assert_called_once()
+
+
+def test_get_parser():
+    test_html = "<html><body>Mocked HTML</body></html>"
+    expected_bs4 = BeautifulSoup(test_html, "html.parser")
+
+    with patch("urllib3.PoolManager.request") as mock_pool_manager:
+        mock_response = MagicMock()
+        mock_response.data = test_html.encode()
+        mock_pool_manager.return_value = mock_response
+
+        results = get_parser()
+        assert results == expected_bs4
+
+
+def test_get_terms_courses_s3_object():
+    s3_client = boto3.client("s3")
+    s3_stubber = Stubber(s3_client)
+
+    expected_params = {"Bucket": BUCKET_NAME, "Key": KEY_PATH}
+    s3_stubber.add_response("get_object", {"Body": "test content"}, expected_params)
+
+    with s3_stubber:
+        result = get_terms_courses_s3_object()
+
+    assert result.bucket_name == BUCKET_NAME
+    assert result.key == KEY_PATH
+
+
+def test_get_terms_courses_dict():
+    s3_object = MagicMock()
+    class_dict = json.dumps(TERMS_COURSES_DICT)
+    s3_object.get.return_value = {"Body": MagicMock(read=lambda: class_dict)}
+
+    with patch(f"{FILE_PATH}.get_terms_courses_s3_object", return_value=s3_object) as mock_s3:
+        result = get_terms_courses_dict()
+        mock_s3.assert_called_once_with()
+
+        assert result == TERMS_COURSES_DICT
+
+
+def test_get_formatted_fall_or_winter_dates():
+    results = get_formatted_fall_or_winter_dates("October 23-27, 2023")
+    expected_dates = ("2023-10-20", "2023-10-30", "2023-11-06")
+    assert results == expected_dates
+
+    results = get_formatted_fall_or_winter_dates("February 19-23, 2024")
+    expected_dates = ("2024-02-16", "2024-02-26", "2024-03-04")
+    assert results == expected_dates
+
+
+def test_get_formatted_summer_dates():
+    results = get_formatted_summer_dates("June 18, 2024", "July 2, 2024")
+    expected_dates = ("2024-06-18", "2024-07-02", "2024-07-02")
+    assert results == expected_dates
+
+
+def test_write_terms_courses_to_s3():
+    s3_object = MagicMock()
+    s3_object.put = MagicMock()
+
+    with patch(f"{FILE_PATH}.get_terms_courses_s3_object", return_value=s3_object) as mock_s3:
+
+        result = write_terms_courses_to_s3(UPDATED_TERMS_COURSES_DICT)
+        mock_s3.assert_called_once_with()
+
+        expected_result = bytes(json.dumps(UPDATED_TERMS_COURSES_DICT).encode("UTF-8"))
+        s3_object.put.assert_called_once_with(Body=expected_result)
+
+        assert result == {"Response": json.dumps("Reading week dates added to Terms and Course file!")}

--- a/webscraping-template.yaml
+++ b/webscraping-template.yaml
@@ -84,3 +84,17 @@ Resources:
       Role: !Ref executionRole
       Architectures:
         - x86_64
+
+  GetReadingWeekDatesFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: WebScraping/functions/getReadingWeekDates
+      Handler: lambda_function.lambda_handler
+      Runtime: python3.11
+      MemorySize: 128
+      Timeout: 30
+      Role: !Ref executionRole
+      Layers:
+        - !Ref Bs4Layer
+      Architectures:
+        - x86_64


### PR DESCRIPTION
The reading week dates we scraped from the academic year page and the added to the terms courses json file. The dates followed the requested format and offsets required for the front-end side. 

These changes include:

- A new "getReadingWeekDates" function 
- The unit tests for the new function
- Updates to the backend to make use for new data

Now the terms api will return its data in the following format:

`
terms: {
"Fall 2023": {
     "ReadingWeekStart": "2023-10-20", 
     "ReadingWeekEnd": "2023-10-30", 
      "ReadingWeekNext": "2023-11-06"
  }
}
`