### PR TITLE
Frontend - list async courses all together

### DIFF
--- a/Frontend/src/common/utils.js
+++ b/Frontend/src/common/utils.js
@@ -87,7 +87,9 @@ export const parseScheduleIntoEvents = (schedules, term, readingWeekDates) => {
         events.push(eventsForCurrentSchedule);
         asyncEvents.push(asyncCoursesForCurrentSchedule)
     });
-    return [events, asyncEvents];
+    const uniqueEvents = removeDuplicateEvents(events);
+    const uniqueAsyncEvents = removeDuplicateAsyncEvents(asyncEvents);
+    return [uniqueEvents, uniqueAsyncEvents];
 };
 
 const convertToDayShortForm = (day) => {
@@ -228,4 +230,28 @@ const createBiWeeklyEvent = (courseCode, section, time, startDate, endDate, crn)
         duration: calculateTimeDifference(time.StartTime, time.EndTime),
         crn: crn
     };
+};
+
+
+const removeDuplicateEvents = (events) => {
+    const uniqueLists = [];
+    const seenLists = new Set();
+
+    for (const sublist of events) {
+        const sublistString = JSON.stringify(sublist);
+        if (!seenLists.has(sublistString)) {
+            uniqueLists.push(sublist);
+            seenLists.add(sublistString);
+        }
+    };
+    return uniqueLists;
+};
+
+const removeDuplicateAsyncEvents = (events) => {
+    const flatArray = events.flat();
+    const uniqueEvents = new Set();
+    flatArray.forEach(obj => {
+        uniqueEvents.add(JSON.stringify(obj));
+    });
+    return Array.from(uniqueEvents).map(obj => JSON.parse(obj));
 };

--- a/Frontend/src/components/CalendarComponent.js
+++ b/Frontend/src/components/CalendarComponent.js
@@ -30,13 +30,16 @@ const MyCalendar = ({ title, events, asyncCourses }) => {
     };
 
     const copyCRNsToClipboard = () => {
-        const courseCRNs = Array.from(new Set(events[scheduleCount].map(event => event.crn)));
-        const asyncCourseCRNs = Array.from(new Set(asyncCourses[scheduleCount].map(event => event.crn)));
-        const allCRNs = courseCRNs.concat(asyncCourseCRNs);
-        const crnString = allCRNs.join(', ');
-        navigator.clipboard.writeText(crnString)
+        const syncCourseCRNs = Array.from(new Set(events[scheduleCount].map(event => event.crn)));
+        const syncStr = syncCourseCRNs.join(', ');
+        const asyncCourseCRNs = Array.from(new Set(asyncCourses.map(event => event.crn)));
+        let asyncStr;
+        navigator.clipboard.writeText(syncStr)
             .then(() => {
-                alert(`CRNs copied to clipboard: ${crnString}`);
+                if (asyncCourseCRNs.length !== 0) {
+                    asyncStr = `\nAsynchronous course CRNs: ${asyncCourseCRNs.join(', ')}`
+                }
+                alert(`CRNs copied to clipboard (${syncStr})` + (asyncStr ? asyncStr : ""));
             })
             .catch((error) => {
                 console.error('Error copying to clipboard:', error);
@@ -66,10 +69,9 @@ const MyCalendar = ({ title, events, asyncCourses }) => {
                 events={events[scheduleCount]}
             />
             <div className="async-courses">
-                {asyncCourses[scheduleCount].length !== 0 && (<p>Courses without assigned meeting times</p>)}
-                {asyncCourses[scheduleCount]?.map((course, index) => (
-                    <p key={index}><b>{course.title}</b></p>
-                ))}
+                {asyncCourses.length > 0 && (<p><b>Courses without assigned meeting times</b></p>)}
+                {asyncCourses.length > 0 && (asyncCourses.map(course => (
+                    <span key={course.crn}><b className="async-course-name">{course.title}</b> - {course.crn}</span>)).reduce((prev, curr) => [prev, ', ', curr]))}
             </div>
         </div >
     );

--- a/Frontend/src/styles/CalendarComponent.css
+++ b/Frontend/src/styles/CalendarComponent.css
@@ -57,3 +57,7 @@
     border-radius: 5px;
     cursor: pointer;
 }
+
+.async-course-name {
+    color: #BF122B;
+}


### PR DESCRIPTION
- All async courses are listed together at the bottom of the calendar
- Removed duplicate schedules (where the only difference was an async course section) -> **so now you only see unique synchronous course combinations** 
- Only synchronous CRNs are copied to clipboard when you click `Export CRNs`
- Asynchronous CRNs are showed below the calendar beside the class + in the alert message