### PR TITLE
Update the getReadingWeekDates function to store data in separate file

### DIFF
--- a/Backend/tests/unit/test_s3_database.py
+++ b/Backend/tests/unit/test_s3_database.py
@@ -17,20 +17,20 @@ CLASSES_DICT = {"AERO 2001-Fall 2023": {
                        "TermDuration": "Full Term", "AlsoRegister": [["A"]], "StartDate": "2023-09-06", "EndDate": "2023-12-08", "WeekSchedule": "Every Week"}]
   }, "ERRORCLASS": {}
 }
-TERMS_COURSES_DICT = {
+TERMS_DICT = {
     "Fall 2023": {
-        "Classes": ["AERO 2001", "AERO 2001 A"],
         "ReadingWeekStart": "2023-10-20", 
         "ReadingWeekEnd": "2023-10-30", 
         "ReadingWeekNext": "2023-11-06"
     }
 }
+TERMS_COURSES_DICT = {"Fall 2023": ["AERO 2001", "AERO 2001 A"]}
 
 @patch('boto3.resource')
 @patch('json.load')
 def generate_db(mock_json_file, mock_boto3_resource) -> S3Database:
     mock_boto3_resource.return_value = Mock()
-    mock_json_file.side_effect = [CLASSES_DICT, TERMS_COURSES_DICT]
+    mock_json_file.side_effect = [CLASSES_DICT, TERMS_DICT, TERMS_COURSES_DICT]
     mock_s3_object = Mock()
     mock_boto3_resource.return_value.Object.return_value = mock_s3_object
     mock_s3_object.get.return_value = {'Body': mock_json_file}

--- a/WebScraping/functions/createTermsCoursesJson/lambda_function.py
+++ b/WebScraping/functions/createTermsCoursesJson/lambda_function.py
@@ -6,7 +6,6 @@ BUCKET_NAME = "carletonschedulingtool"
 KEY_PATH = "web-scraping-stepfunction/"
 CLASSES_FILENAME = "classes.json"
 TERMS_COURSES_FILENAME = "terms_courses.json"
-CLASSES_KEY = "Classes"
 
 def lambda_handler(event: dict, context: dict) -> str:
     terms_courses_dict = {}
@@ -15,10 +14,10 @@ def lambda_handler(event: dict, context: dict) -> str:
     for course in classes_list:
         subject = course["Subject"]
         term_key = course["Term"]
-        terms_courses_dict.setdefault(term_key, {}).setdefault(CLASSES_KEY, []).append(subject)
+        terms_courses_dict.setdefault(term_key, []).append(subject)
         
         for lecture in course["LectureSections"]:
-            terms_courses_dict.get(term_key).get(CLASSES_KEY).append(f"{subject} {lecture['SectionID']}")
+            terms_courses_dict.get(term_key).append(f"{subject} {lecture['SectionID']}")
 
     return write_terms_courses_to_s3(terms_courses_dict)
             

--- a/WebScraping/functions/getReadingWeekDates/lambda_function.py
+++ b/WebScraping/functions/getReadingWeekDates/lambda_function.py
@@ -3,18 +3,19 @@ import boto3
 from datetime import datetime, timedelta
 import urllib3
 from bs4 import BeautifulSoup
-from typing import Tuple
+from typing import Tuple, List
 
 BASE_URL = "https://calendar.carleton.ca/academicyear"
 HTTP = urllib3.PoolManager()
 BUCKET_NAME = "carletonschedulingtool"
-KEY_PATH = "web-scraping-stepfunction/terms_courses.json"
+KEY_PATH = "web-scraping-stepfunction/"
 
 def lambda_handler(event: dict, context: dict) -> str:
     parser = get_parser()
-    terms_courses_dict = get_terms_courses_dict()
+    terms_dict = {}
+    terms = get_terms_from_class_dict(get_classes_dict())
     
-    for term in terms_courses_dict.keys():
+    for term in terms:
         name, year = term.split()
         term_search_str = f"{name.upper()} TERM {year}"
         term_tbody = parser.find("td", string=term_search_str).find_parent("tbody")
@@ -34,12 +35,13 @@ def lambda_handler(event: dict, context: dict) -> str:
             
             start_week, end_week, next_week = get_formatted_summer_dates(start_date, end_date)
 
-
-        terms_courses_dict[term]["ReadingWeekStart"] = start_week
-        terms_courses_dict[term]["ReadingWeekEnd"] = end_week
-        terms_courses_dict[term]["ReadingWeekNext"] = next_week
+        terms_dict[term] = {
+            "ReadingWeekStart": start_week,
+            "ReadingWeekEnd": end_week,
+            "ReadingWeekNext": next_week
+        }
         
-    return write_terms_courses_to_s3(terms_courses_dict)
+    return write_terms_file_to_s3(terms_dict)
 
 
 def get_parser() -> BeautifulSoup:
@@ -54,26 +56,48 @@ def get_parser() -> BeautifulSoup:
     return BeautifulSoup(html, "html.parser")
 
 
-def get_terms_courses_s3_object() -> object:
+def get_s3_object(filename: str) -> object:
     '''
-    Gets the terms courses s3 file object.
-
-    Returns:
+    Gets the s3 file object where the href list and classes files are.
+    
+    Parameters:
+    filename: The filename of the object to get.
+    
+    Returns
     S3 Object: The s3 file object.
     '''
     s3 = boto3.resource("s3")
-    return s3.Object(BUCKET_NAME, KEY_PATH)
-    
+    return s3.Object(BUCKET_NAME, KEY_PATH + filename)
 
-def get_terms_courses_dict() -> dict:
+
+def get_classes_dict() -> dict:
     '''
-    Gets the list of classes from s3.
+    Gets the dict of classes from s3.
     
     Returns:
     dict: terms course dict.
     '''
-    terms_courses_file = get_terms_courses_s3_object()
-    return json.load(terms_courses_file.get()["Body"])
+    classes_file = get_s3_object("classes.json")
+    return json.load(classes_file.get()["Body"])
+
+
+def get_terms_from_class_dict(classes_dict: dict) -> List:
+    '''
+    Gets the terms from a class dictionary.
+
+    Parameters: 
+    classes_dict: The dictionary used.
+
+    Returns: 
+    list: list of the terms obtained.
+    '''
+    term_lst = []
+    for course in classes_dict:
+        term = classes_dict[course]['Term']
+        if not term in term_lst:
+            term_lst.append(term)
+
+    return term_lst
 
 
 def get_formatted_fall_or_winter_dates(date_str: str) -> Tuple[str, str, str]:
@@ -122,9 +146,9 @@ def get_formatted_summer_dates(start_date: str, end_date: str) -> Tuple[str, str
     return formatted_start_date, formatted_end_date, formatted_end_date
 
 
-def write_terms_courses_to_s3(updated_terms_courses: dict[str, str]) -> str:
+def write_terms_file_to_s3(terms_dict: dict) -> str:
     '''
-    Writes updated terms courses file to S3.
+    Writes terms file to S3.
 
     Parameters: 
     updated_terms_courses: dictionary of containing terms with courses and reading week dates.
@@ -132,9 +156,9 @@ def write_terms_courses_to_s3(updated_terms_courses: dict[str, str]) -> str:
     Returns:
     str: Message indicating the terms and courses file has been updated.
     '''
-    terms_courses_file = get_terms_courses_s3_object()
-    terms_courses_file.put(Body=(bytes(json.dumps(updated_terms_courses).encode("UTF-8"))))
+    terms_file = get_s3_object("terms.json")
+    terms_file.put(Body=(bytes(json.dumps(terms_dict).encode("UTF-8"))))
     
     return {
-        "Response": json.dumps("Reading week dates added to Terms and Course file!")
+        "Response": json.dumps("Terms JSON written to s3 with reading week dates!")
     }

--- a/WebScraping/tests/unit/test_create_terms_courses_json.py
+++ b/WebScraping/tests/unit/test_create_terms_courses_json.py
@@ -32,7 +32,7 @@ def test_lambda_handler():
         with patch(f"{FILE_PATH}.write_terms_courses_to_s3") as mock_write_terms:
             lambda_handler(event=None, context=None)
 
-            expected_result = {"Fall 2023": {"Classes": ["AERO 2001", "AERO 2001 A"]}}
+            expected_result = {"Fall 2023": ["AERO 2001", "AERO 2001 A"]}
             mock_write_terms.assert_called_once_with(expected_result)
 
 

--- a/WebScraping/tests/unit/test_get_reading_week_dates.py
+++ b/WebScraping/tests/unit/test_get_reading_week_dates.py
@@ -4,24 +4,46 @@ from botocore.stub import Stubber
 
 FILE_PATH = "WebScraping.functions.getReadingWeekDates.lambda_function"
 
-TERMS_COURSES_DICT = {
+TERMS_DICT = {
     "Fall 2023": {
-        "Classes": ["SYSC 4001", "SYSC 4001 A"]
-    },
-    "Winter 2024": {
-        "Classes": ["SYSC 3200", "SYSC 3200 A"]
-    },
-    "Summer 2024": {
-        "Classes": ["SYSC 2006", "SYSC 2006 A"]
-    }
-}
-
-UPDATED_TERMS_COURSES_DICT = {
-    "Fall 2023": {
-        "Classes": ["SYSC 4001", "SYSC 4001 A"],
         "ReadingWeekStart": "2023-10-21", 
         "ReadingWeekEnd": "2023-10-30", 
         "ReadingWeekNext": "2023-11-06"
+    }
+}
+
+CLASSES_DICT = {
+    "AERO 2001-Fall 2023": {
+        "Subject": "AERO 2001",
+        "Term": "Fall 2023", 
+        "Title": "Aerospace Engineering Graphical Design", 
+        "Prerequisite": "Second-year status in Engineering.", 
+        "LectureSections": [], 
+        "LabSections": []
+    },
+    "SYSC 4101-Fall 2023": {
+        "Subject": "SYSC 4101",
+        "Term": "Fall 2023", 
+        "Title": "Software Validation", 
+        "Prerequisite": "SYSC 3120 or SYSC 3020.", 
+        "LectureSections": [], 
+        "LabSections": []
+    },
+    "AERO 2001-Winter 2024": {
+        "Subject": "AERO 2001",
+        "Term": "Winter 2024", 
+        "Title": "Aerospace Engineering Graphical Design", 
+        "Prerequisite": "Second-year status in Engineering.", 
+        "LectureSections": [], 
+        "LabSections": []
+    },
+    "AERO 2001-Summer 2024": {
+        "Subject": "AERO 2001",
+        "Term": "Summer 2024", 
+        "Title": "Aerospace Engineering Graphical Design", 
+        "Prerequisite": "Second-year status in Engineering.", 
+        "LectureSections": [], 
+        "LabSections": []
     }
 }
 
@@ -64,18 +86,18 @@ MOCK_HTML = """
 
 def test_lambda_handler():
     with patch(f'{FILE_PATH}.get_parser') as mock_get_parser, \
-         patch(f'{FILE_PATH}.get_terms_courses_dict') as mock_get_terms_courses_dict, \
-         patch(f'{FILE_PATH}.write_terms_courses_to_s3') as mock_write_terms_courses_to_s3:
+         patch(f'{FILE_PATH}.get_classes_dict') as mock_get_classes_dict, \
+         patch(f'{FILE_PATH}.write_terms_file_to_s3') as mock_write_terms_file_to_s3:
         
         mock_get_parser.return_value = BeautifulSoup(MOCK_HTML, "html.parser")
-        mock_get_terms_courses_dict.return_value = TERMS_COURSES_DICT
-        mock_write_terms_courses_to_s3.return_value = {"Response": json.dumps("Reading week dates added to Terms and Course file!")}
+        mock_get_classes_dict.return_value = CLASSES_DICT
+        mock_write_terms_file_to_s3.return_value = {"Response": json.dumps("Terms JSON written to s3 with reading week dates!")}
 
         lambda_handler({}, {})
 
         mock_get_parser.assert_called_once()
-        mock_get_terms_courses_dict.assert_called_once()
-        mock_write_terms_courses_to_s3.assert_called_once()
+        mock_get_classes_dict.assert_called_once()
+        mock_write_terms_file_to_s3.assert_called_once()
 
 
 def test_get_parser():
@@ -91,7 +113,7 @@ def test_get_parser():
         assert results == expected_bs4
 
 
-def test_get_terms_courses_s3_object():
+def test_get_s3_object():
     s3_client = boto3.client("s3")
     s3_stubber = Stubber(s3_client)
 
@@ -99,22 +121,28 @@ def test_get_terms_courses_s3_object():
     s3_stubber.add_response("get_object", {"Body": "test content"}, expected_params)
 
     with s3_stubber:
-        result = get_terms_courses_s3_object()
+        result = get_s3_object("test.json")
 
     assert result.bucket_name == BUCKET_NAME
-    assert result.key == KEY_PATH
+    assert result.key == KEY_PATH + "test.json"
 
 
-def test_get_terms_courses_dict():
+def test_get_classes_dict():
     s3_object = MagicMock()
-    class_dict = json.dumps(TERMS_COURSES_DICT)
+    class_dict = json.dumps(CLASSES_DICT)
     s3_object.get.return_value = {"Body": MagicMock(read=lambda: class_dict)}
 
-    with patch(f"{FILE_PATH}.get_terms_courses_s3_object", return_value=s3_object) as mock_s3:
-        result = get_terms_courses_dict()
-        mock_s3.assert_called_once_with()
+    with patch(f"{FILE_PATH}.get_s3_object", return_value=s3_object) as mock_s3:
+        result = get_classes_dict()
+        mock_s3.assert_called_once_with("classes.json")
 
-        assert result == TERMS_COURSES_DICT
+        assert result == CLASSES_DICT
+
+
+def test_get_terms_from_class_dict():
+    results = get_terms_from_class_dict(CLASSES_DICT)
+    expected_terms = ["Fall 2023", "Winter 2024", "Summer 2024"]
+    assert results == expected_terms
 
 
 def test_get_formatted_fall_or_winter_dates():
@@ -133,16 +161,16 @@ def test_get_formatted_summer_dates():
     assert results == expected_dates
 
 
-def test_write_terms_courses_to_s3():
+def test_write_terms_file_to_s3():
     s3_object = MagicMock()
     s3_object.put = MagicMock()
 
-    with patch(f"{FILE_PATH}.get_terms_courses_s3_object", return_value=s3_object) as mock_s3:
+    with patch(f"{FILE_PATH}.get_s3_object", return_value=s3_object) as mock_s3:
 
-        result = write_terms_courses_to_s3(UPDATED_TERMS_COURSES_DICT)
-        mock_s3.assert_called_once_with()
+        result = write_terms_file_to_s3(TERMS_DICT)
+        mock_s3.assert_called_once_with("terms.json")
 
-        expected_result = bytes(json.dumps(UPDATED_TERMS_COURSES_DICT).encode("UTF-8"))
+        expected_result = bytes(json.dumps(TERMS_DICT).encode("UTF-8"))
         s3_object.put.assert_called_once_with(Body=expected_result)
 
-        assert result == {"Response": json.dumps("Reading week dates added to Terms and Course file!")}
+        assert result == {"Response": json.dumps("Terms JSON written to s3 with reading week dates!")}


### PR DESCRIPTION
The getReadingWeekDates function now stores the date in its own file called "terms.json" which can directly be sent to the frontend. Due to this update the "terms_courses.json" file now just contains the class list (as it did before). 