### PR TITLE
Frontend - Addressed async course issue

### DIFF
--- a/Frontend/src/common/utils.js
+++ b/Frontend/src/common/utils.js
@@ -37,7 +37,6 @@ export const parseInputs = (inputs) => {
 
 export const parseScheduleIntoEvents = (schedules, term, readingWeekDates) => {
     const events = [];
-    const asyncEvents = [];
     schedules.forEach(schedule => {
         const eventsForCurrentSchedule = [];
         const asyncCoursesForCurrentSchedule = [];
@@ -78,7 +77,7 @@ export const parseScheduleIntoEvents = (schedules, term, readingWeekDates) => {
             if (courseData.Times.length === 0) {
                 const asyncData = {
                     title: `${courseCode}${section}`,
-                    crn: courseData.CRN
+                    crn: courseData.CRN,
                 }
                 asyncCoursesForCurrentSchedule.push(asyncData);
             }
@@ -86,12 +85,13 @@ export const parseScheduleIntoEvents = (schedules, term, readingWeekDates) => {
         if (eventsForCurrentSchedule.length > 0) {
             assignColoursToEvents(eventsForCurrentSchedule, colours);
         }
-        events.push(eventsForCurrentSchedule);
-        asyncEvents.push(asyncCoursesForCurrentSchedule)
+        events.push({
+            "sync": eventsForCurrentSchedule,
+            "async": asyncCoursesForCurrentSchedule
+        });
     });
     const uniqueEvents = removeDuplicateEvents(events);
-    const uniqueAsyncEvents = removeDuplicateAsyncEvents(asyncEvents);
-    return [uniqueEvents, uniqueAsyncEvents];
+    return uniqueEvents;
 };
 
 export const getCourseTime = (milliseconds) => {
@@ -253,21 +253,16 @@ const removeDuplicateEvents = (events) => {
     const uniqueLists = [];
     const seenLists = new Set();
 
-    for (const sublist of events) {
-        const sublistString = JSON.stringify(sublist);
+    for (let i = 0; i < events.length; i++) {
+        let obj = events[i];
+        const sublistString = JSON.stringify(obj["sync"]);
         if (!seenLists.has(sublistString)) {
-            uniqueLists.push(sublist);
+            uniqueLists.push({
+                "sync": obj["sync"],
+                "async": obj["async"]
+            });
             seenLists.add(sublistString);
         }
-    };
+    }
     return uniqueLists;
-};
-
-const removeDuplicateAsyncEvents = (events) => {
-    const flatArray = events.flat();
-    const uniqueEvents = new Set();
-    flatArray.forEach(obj => {
-        uniqueEvents.add(JSON.stringify(obj));
-    });
-    return Array.from(uniqueEvents).map(obj => JSON.parse(obj));
 };

--- a/Frontend/src/components/CalendarComponent.js
+++ b/Frontend/src/components/CalendarComponent.js
@@ -5,7 +5,7 @@ import rrulePlugin from '@fullcalendar/rrule';
 import '../styles/CalendarComponent.css';
 import { getCourseTime } from '../common/utils';
 
-const MyCalendar = ({ title, events, asyncCourses }) => {
+const MyCalendar = ({ title, events }) => {
     const [scheduleCount, setScheduleCount] = useState(0);
 
     const handlePrevClick = () => {
@@ -17,9 +17,10 @@ const MyCalendar = ({ title, events, asyncCourses }) => {
     };
 
     const earliestStartDate = (courses) => {
-        let earliestDate = courses[0][0].startRecur;
+        let earliestDate = courses[0]["sync"][0].startRecur;
         for (const schedule of courses) {
-            for (const course of schedule) {
+            const obj = schedule["sync"];
+            for (const course of obj) {
                 const currDate = course.startRecur;
                 if (currDate < earliestDate) {
                     earliestDate = currDate;
@@ -30,9 +31,9 @@ const MyCalendar = ({ title, events, asyncCourses }) => {
     };
 
     const copyCRNsToClipboard = () => {
-        const syncCourseCRNs = Array.from(new Set(events[scheduleCount].map(event => event.crn)));
+        const syncCourseCRNs = Array.from(new Set(events[scheduleCount]["sync"].map(event => event.crn)));
         const syncStr = syncCourseCRNs.join(', ');
-        const asyncCourseCRNs = Array.from(new Set(asyncCourses.map(event => event.crn)));
+        const asyncCourseCRNs = Array.from(new Set(events[scheduleCount]["async"].map(event => event.crn)));
         let asyncStr;
         navigator.clipboard.writeText(syncStr)
             .then(() => {
@@ -47,7 +48,6 @@ const MyCalendar = ({ title, events, asyncCourses }) => {
     };
 
     const handleEventClick = (event) => {
-        console.log("wtf")
         const title = event["event"]["_def"]["title"];
         const crn = event["event"]["_def"]["extendedProps"]["crn"];
         const instructor = event["event"]["_def"]["extendedProps"]["instructor"];
@@ -94,13 +94,14 @@ const MyCalendar = ({ title, events, asyncCourses }) => {
                 dayHeaderFormat={{ weekday: 'long' }}
                 height="auto"
                 initialDate={earliestStartDate(events)}
-                events={events[scheduleCount]}
+                events={events[scheduleCount]["sync"]}
                 eventClick={handleEventClick}
             />
             <div className="async-courses">
-                {asyncCourses.length > 0 && (<p><b>Courses without assigned meeting times</b></p>)}
-                {asyncCourses.length > 0 && (asyncCourses.map(course => (
-                    <span key={course.crn}><b className="async-course-name">{course.title}</b> - {course.crn}</span>)).reduce((prev, curr) => [prev, ', ', curr]))}
+                {events[scheduleCount]["async"].length !== 0 && (<p>Courses without assigned meeting times</p>)}
+                {events[scheduleCount]["async"]?.map((course, index) => (
+                    <span key={index}><b className="async-course-name">{course.title}</b> - {course.crn}</span>)).reduce((prev, curr) => [prev, ', ', curr])
+                }
             </div>
         </div >
     );

--- a/Frontend/src/components/CalendarComponent.js
+++ b/Frontend/src/components/CalendarComponent.js
@@ -99,7 +99,7 @@ const MyCalendar = ({ title, events }) => {
             />
             <div className="async-courses">
                 {events[scheduleCount]["async"].length !== 0 && (<p>Courses without assigned meeting times</p>)}
-                {events[scheduleCount]["async"]?.map((course, index) => (
+                {events[scheduleCount]["async"].length !== 0 && events[scheduleCount]["async"]?.map((course, index) => (
                     <span key={index}><b className="async-course-name">{course.title}</b> - {course.crn}</span>)).reduce((prev, curr) => [prev, ', ', curr])
                 }
             </div>

--- a/Frontend/src/components/FormComponent.js
+++ b/Frontend/src/components/FormComponent.js
@@ -28,7 +28,6 @@ const FormComponent = () => {
     const [inputValues, setInputValues] = useState(initialFormState);
     const [isFormSubmitted, setIsFormSubmitted] = useState(false);
     const [events, setEvents] = useState([]);
-    const [asyncEvents, setAsyncEvents] = useState([]);
     const [nonEmptyCoursesCount, setNoneEmptyCoursesCount] = useState(0);
     const [coursesList, setCoursesList] = useState({});
     const [termsAndReadingWeek, setTermsAndReadingWeek] = useState({});
@@ -131,8 +130,7 @@ const FormComponent = () => {
 
         if (isValidSubmission && nonEmptyCoursesCount > 0) {
             fetchSchedules(inputValues, termsAndReadingWeek).then((classes) => {
-                setEvents(classes[0]);
-                setAsyncEvents(classes[1])
+                setEvents(classes);
                 setIsFormSubmitted(true);
             }).catch((error) => {
                 if (error.name === NO_SCHEDULES_ERROR || error.name === ALL_ASYNC_COURSES_ERROR) {
@@ -150,7 +148,6 @@ const FormComponent = () => {
     const handleClear = () => {
         setIsFormSubmitted(false);
         setEvents([]);
-        setAsyncEvents([]);
     };
 
     const handleClearAll = () => {
@@ -182,7 +179,7 @@ const FormComponent = () => {
     return isFormSubmitted ? (
         <div className="schedule-view">
             <button id="back-to-form" type="button" onClick={() => setIsFormSubmitted(false)}>Back to Form</button>
-            <Calendar title={inputValues.term} events={events} asyncCourses={asyncEvents} />
+            <Calendar title={inputValues.term} events={events} />
         </div>
     ) : (
         <div className="form-container">


### PR DESCRIPTION
Events are now parsed in the following format: 
```json
{
   "sync": Array of sync events, 
    "async": array of async events
}
```

This way for each schedule the sync and async courses are interlinked. I then loop through the whole list and remove objects that have duplicate 'sync' arrays. 

Allowed me to remove useState for asyncEvents because now all the events are encapsulated together in an object. Updated accesses to include 'sync' or 'async' keys in the Calendar component. 