### PR TITLE
Add default reading week dates

### DIFF
--- a/WebScraping/functions/getReadingWeekDates/lambda_function.py
+++ b/WebScraping/functions/getReadingWeekDates/lambda_function.py
@@ -3,17 +3,113 @@ import boto3
 from datetime import datetime, timedelta
 import urllib3
 from bs4 import BeautifulSoup
-from typing import Tuple, List
+from typing import Tuple, List, Dict
 
 BASE_URL = "https://calendar.carleton.ca/academicyear"
 HTTP = urllib3.PoolManager()
 BUCKET_NAME = "carletonschedulingtool"
 KEY_PATH = "web-scraping-stepfunction/"
+DEFAULT_DATES = {
+    "Fall": {
+        "ReadingWeekStart": "2023-10-21", 
+        "ReadingWeekEnd": "2023-10-30", 
+        "ReadingWeekNext": "2023-11-06"
+    }, 
+    "Winter": {
+        "ReadingWeekStart": "2024-02-17", 
+        "ReadingWeekEnd": "2024-02-26", 
+        "ReadingWeekNext": "2024-03-04"
+        
+    },
+    "Summer": {
+        "ReadingWeekStart": "2024-06-18", 
+        "ReadingWeekEnd": "2024-07-02", 
+        "ReadingWeekNext": "2024-07-02"
+    }
+}
 
-def lambda_handler(event: dict, context: dict) -> str:
-    parser = get_parser()
-    terms_dict = {}
+def lambda_handler(event: Dict, context: Dict) -> str:
     terms = get_terms_from_class_dict(get_classes_dict())
+    response = make_http_request()
+    
+    # When response status is 200 (successful) then scrape terms
+    if response.status == 200:
+        html = response.data.decode("utf-8")
+        parser = BeautifulSoup(html, "html.parser")
+        terms_dict = get_scraped_terms_dict(terms, parser)
+
+    else:
+        terms_dict = get_default_terms_dict(terms)
+    
+    return write_terms_file_to_s3(terms_dict)
+
+
+def make_http_request() -> urllib3.HTTPResponse:
+    '''
+    Makes http GET request to BASE_URL.
+
+    Returns:
+    urllib3.HTTPResponse: repsonse of the GET request.
+    '''
+    return HTTP.request("GET", BASE_URL)
+
+
+def get_s3_object(filename: str) -> object:
+    '''
+    Gets the s3 file object where the href list and classes files are.
+    
+    Parameters:
+    filename: The filename of the object to get.
+    
+    Returns
+    S3 Object: The s3 file object.
+    '''
+    s3 = boto3.resource("s3")
+    return s3.Object(BUCKET_NAME, KEY_PATH + filename)
+
+
+def get_classes_dict() -> Dict:
+    '''
+    Gets the dict of classes from s3.
+    
+    Returns:
+    dict: terms course dict.
+    '''
+    classes_file = get_s3_object("classes.json")
+    return json.load(classes_file.get()["Body"])
+
+
+def get_terms_from_class_dict(classes_dict: Dict) -> List:
+    '''
+    Gets the terms from a class dictionary.
+
+    Parameters: 
+    classes_dict: The dictionary used.
+
+    Returns: 
+    list: list of the terms obtained.
+    '''
+    term_lst = []
+    for course in classes_dict:
+        term = classes_dict[course]['Term']
+        if not term in term_lst:
+            term_lst.append(term)
+
+    return term_lst
+
+
+def get_scraped_terms_dict(terms: List, parser: BeautifulSoup) -> Dict:
+    '''
+    Extracts and formats reading week dates for each term from the parsed HTML.
+
+    Parameters:
+    terms: List of terms obtained from the class dictionary.
+    parser: BeautifulSoup html parser object.
+
+    Returns:
+    Dict: Dictionary containing reading week dates for each term.
+    '''
+    scraped_terms_dict = {}
     
     for term in terms:
         name, year = term.split()
@@ -35,69 +131,31 @@ def lambda_handler(event: dict, context: dict) -> str:
             
             start_week, end_week, next_week = get_formatted_summer_dates(start_date, end_date)
 
-        terms_dict[term] = {
+        scraped_terms_dict[term] = {
             "ReadingWeekStart": start_week,
             "ReadingWeekEnd": end_week,
             "ReadingWeekNext": next_week
         }
-        
-    return write_terms_file_to_s3(terms_dict)
-
-
-def get_parser() -> BeautifulSoup:
-    '''
-    Gets the bs4 html parser.
-
-    Returns:
-    BeautifulSoup: html parser object.
-    '''
-    req = HTTP.request("GET", BASE_URL)
-    html = req.data.decode("utf-8")
-    return BeautifulSoup(html, "html.parser")
-
-
-def get_s3_object(filename: str) -> object:
-    '''
-    Gets the s3 file object where the href list and classes files are.
     
+    return scraped_terms_dict
+
+
+def get_default_terms_dict(terms: List) -> Dict:
+    '''
+    Creates a default terms dictionary with predefined dates.
+
     Parameters:
-    filename: The filename of the object to get.
-    
-    Returns
-    S3 Object: The s3 file object.
-    '''
-    s3 = boto3.resource("s3")
-    return s3.Object(BUCKET_NAME, KEY_PATH + filename)
+    terms: List of terms obtained from the class dictionary.
 
-
-def get_classes_dict() -> dict:
-    '''
-    Gets the dict of classes from s3.
-    
     Returns:
-    dict: terms course dict.
+    Dict: Default terms dictionary with predefined dates.
     '''
-    classes_file = get_s3_object("classes.json")
-    return json.load(classes_file.get()["Body"])
-
-
-def get_terms_from_class_dict(classes_dict: dict) -> List:
-    '''
-    Gets the terms from a class dictionary.
-
-    Parameters: 
-    classes_dict: The dictionary used.
-
-    Returns: 
-    list: list of the terms obtained.
-    '''
-    term_lst = []
-    for course in classes_dict:
-        term = classes_dict[course]['Term']
-        if not term in term_lst:
-            term_lst.append(term)
-
-    return term_lst
+    default_terms_dict = {}
+    
+    for term in terms:
+        default_terms_dict[term] = DEFAULT_DATES.get(term.split(" ")[0], {})
+        
+    return default_terms_dict
 
 
 def get_formatted_fall_or_winter_dates(date_str: str) -> Tuple[str, str, str]:
@@ -146,7 +204,7 @@ def get_formatted_summer_dates(start_date: str, end_date: str) -> Tuple[str, str
     return formatted_start_date, formatted_end_date, formatted_end_date
 
 
-def write_terms_file_to_s3(terms_dict: dict) -> str:
+def write_terms_file_to_s3(terms_dict: Dict) -> str:
     '''
     Writes terms file to S3.
 


### PR DESCRIPTION
Default reading dates were added to the getReadingDates functions to handle any cases where the http request failed (status code not 200). This was done to ensure there will always be dates returned to the frontend. The unit tests have been updated accordingly.