### PR TITLE
Clear calendar when input values change

### DIFF
--- a/Frontend/src/components/FormComponent.js
+++ b/Frontend/src/components/FormComponent.js
@@ -122,6 +122,7 @@ const FormComponent = ({ setDisplayCalendar, setTerm, setSchedules, setScheduleC
     }, [inputValues.term]);
 
     const handleInputChange = (inputName, selectedOption) => {
+        setDisplayCalendar(false);
         const selectedTerm = selectedOption ? selectedOption : '';
 
         setInputValues({


### PR DESCRIPTION
Clear calendar when input values change. This also fixes a bug where if you were to generate a Fall schedule, then a Winter schedule the date ranges would not change (it would stay as fall dates)