### PR TITLE
Added additional fields returned from "generateSchedules" API

### DIFF
--- a/Backend/src/database/database.py
+++ b/Backend/src/database/database.py
@@ -60,13 +60,13 @@ class CourseDatabase(ABC):
         term = course_map.get(self.term_column, "")
         prerequisite = course_map.get(self.prerequisite_column, "")
         lecture_section_list = course_map.get(self.lecture_sections_column, [])
-        lecture_sections = [self.convert_to_section(subject, section_map) for section_map in lecture_section_list]
+        lecture_sections = [self.convert_to_section(subject, title, term, prerequisite, section_map) for section_map in lecture_section_list]
         lab_section_list = course_map.get(self.lab_sections_column, [])
-        lab_sections = [self.convert_to_section(subject, section_map) for section_map in lab_section_list]
+        lab_sections = [self.convert_to_section(subject, title, term, prerequisite, section_map) for section_map in lab_section_list]
 
         return Course(subject, title, term, prerequisite, lecture_sections, lab_sections, None)
     
-    def convert_to_section(self, course_code: str, section_map: dict) -> Section:
+    def convert_to_section(self, course_code: str, title: str, term: str, prerequisite: str, section_map: dict) -> Section:
         section_id = section_map.get(self.section_id_column, "")
         crn = section_map.get(self.crn_column, "")
         status = section_map.get(self.status_column, "")
@@ -78,7 +78,8 @@ class CourseDatabase(ABC):
         week_schedule = WeekSchedule(section_map.get(self.week_schedule_column, WeekSchedule.EVERY_WEEK))
         meeting_dates_list = section_map.get(self.meeting_dates_column, [])
         meeting_times = [self.convert_to_classtime(term_duration, meeting_date_map, week_schedule) for meeting_date_map in meeting_dates_list]
-        return Section(course_code, section_id, crn, instructor, meeting_times, status, related_sections, start_date, end_date)
+        return Section(course_code, section_id, crn, instructor, meeting_times, status, title, 
+                       term, prerequisite, related_sections, start_date, end_date)
 
     def convert_to_classtime(self, term_duration: TermDuration, meeting_date_map: dict, week_schedule: WeekSchedule) -> ClassTime:
         day_of_week = DayOfWeek(meeting_date_map.get(self.day_of_week_column))

--- a/Backend/src/database/database_error.py
+++ b/Backend/src/database/database_error.py
@@ -29,7 +29,7 @@ class ErrorCourseDatabase(CourseDatabase):
     def convert_to_course(self, course_map: dict):
         self.exception()
     
-    def convert_to_section(self, course_code: str, section_map: dict):
+    def convert_to_section(self, course_code: str, title: str, term: str, prerequisite: str, section_map: dict):
         self.exception()
         
     def convert_to_classtime(self, term_duration: TermDuration, meeting_date_map: dict, week_schedule: WeekSchedule):

--- a/Backend/src/model/section.py
+++ b/Backend/src/model/section.py
@@ -10,6 +10,9 @@ class Section:
     instructor: str
     times: List[ClassTime]
     status: str
+    title: str
+    term: str
+    prerequisite: str
     related_section_ids: List[List[str]] # Section IDs that must registered in with the given section 
                                          # i.e. [["ETU"], ["L1", "L2"]] would represent ETU and (L1 or L2)
     start_date: str
@@ -18,4 +21,5 @@ class Section:
     def to_dict(self) -> dict:
         return {"CourseCode":self.course_code, "SectionID":self.section_id, "CRN":self.crn, 
                 "Instructor":self.instructor, "Times":[time.to_dict() for time in self.times],
-                "Status":self.status, "StartDate": self.start_date, "EndDate": self.end_date}
+                "Status":self.status, "StartDate": self.start_date, "EndDate": self.end_date,
+                "Title":self.title, "Term":self.term, "Prerequisite":self.prerequisite}

--- a/Backend/tests/unit/test_course.py
+++ b/Backend/tests/unit/test_course.py
@@ -7,8 +7,8 @@ from Backend.src.model.filter import Filter
 from Backend.src.model.term_duration import TermDuration
 
 def test_filter_before_time():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", [], "2023-09-06", "2023-12-08") 
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08") 
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
 
     course.filter_before_time("13:00")
@@ -19,8 +19,8 @@ def test_filter_before_time():
         course.filter_before_time(12.00)
 
 def test_filter_after_time():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", [], "2023-09-06", "2023-12-08") 
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08") 
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
 
     course.filter_after_time("13:00")
@@ -31,8 +31,8 @@ def test_filter_after_time():
         course.filter_after_time(10)
 
 def test_filter_day_off():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08") 
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08") 
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
 
     course.filter_day_off(DayOfWeek.MONDAY)
@@ -43,8 +43,8 @@ def test_filter_day_off():
         course.filter_day_off("MONDAY")
 
 def test_filter_between_times():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", [], "2023-09-06", "2023-12-08") 
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", " JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "15:00", "18:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08") 
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
 
     course.filter_between_times([ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "06:00", "09:30"), ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "17:00", "19:00")])
@@ -55,8 +55,8 @@ def test_filter_between_times():
         course.filter_between_times("Mon-Fri")
 
 def test_filter_by_section():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
 
     course.filter_by_section()
@@ -68,10 +68,10 @@ def test_filter_by_section():
         course.filter_by_section()
 
 def test_filter_all_courses():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE2000", "A", "11111", "JON", [ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "07:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section4 = Section("CODE2000", "B", "22222", "JON", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE2000", "A", "11111", "JON", [ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "07:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE2000", "B", "22222", "JON", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], "B")
     course2 = Course("CODE2000", "CLASS NAME 2", "FALL", "N/A", [section3], [section4], None)
     filter = Filter(before_time = "08:00", day_of_week = DayOfWeek.MONDAY, after_time = "22:00", between_times=[ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "18:00", "23:00")])
@@ -86,8 +86,8 @@ def test_filter_all_courses():
     
 
 def test_filter():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section2], [], None)
     course.filter(Filter())
     assert course.lecture_sections == [section1, section2]
@@ -97,9 +97,9 @@ def test_filter():
         course.filter(None)
 
 def test_get_lecture_section():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE2000", "A", "11113", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE2000", "A", "11113", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
 
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1, section3], [section2], None)
     assert course.get_lecture_section("A") == section1
@@ -107,9 +107,9 @@ def test_get_lecture_section():
     assert course.get_lecture_section("C") == None
 
 def test_get_lab_section():
-    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE3000", "B", "22225", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "JON", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "22222", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "B", "22225", "JON", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:00", "12:00")], "OPEN", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     course = Course("CODE1000", "CLASS NAME", "FALL", "N/A", [section1], [section2, section3], None)
     assert course.get_lab_section("A") == None
     assert course.get_lab_section("B") == section2

--- a/Backend/tests/unit/test_database_error.py
+++ b/Backend/tests/unit/test_database_error.py
@@ -25,7 +25,7 @@ def test_convert_to_course():
 
 def test_convert_to_section():
     with pytest.raises(CouresDatabaseException):
-        error_db.convert_to_section(None, None)
+        error_db.convert_to_section(None, None, None, None, None)
     
 def test_convert_to_classtime():
     with pytest.raises(CouresDatabaseException):

--- a/Backend/tests/unit/test_endpoints.py
+++ b/Backend/tests/unit/test_endpoints.py
@@ -16,7 +16,7 @@ from Backend.tests.unit.test_dynamo_database import test_scan_response1 as respo
 from Backend.tests.unit.test_s3_database import generate_db
 
 TEST_TERM = "Fall 2023"
-SAMPLE_SCHEDULE = [[Section("SYSC 4001", "B", "35905", "Test Prof 2", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "08:35", "11:25")], "Registration Closed", [], "2023-09-06", "2023-12-08").to_dict()]]
+SAMPLE_SCHEDULE = [[Section("SYSC 4001", "B", "35905", "Test Prof 2", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "08:35", "11:25")], "Registration Closed", "Operating Systems", TEST_TERM, "fourth-year standing.", [], "2023-09-06", "2023-12-08").to_dict()]]
 
 @pytest.fixture()
 def empty_json_event():

--- a/Backend/tests/unit/test_scheduler.py
+++ b/Backend/tests/unit/test_scheduler.py
@@ -10,13 +10,13 @@ def test_is_section_schedulable():
     '''
     Tests that isSectionShedulable can handle overlaping classes and schedulable classes
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [], "2023-09-06", "2023-12-08")
-    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     schedule = [
-        Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.MONDAY, TermDuration.EARLY_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.EARLY_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08"),
-        Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.LATE_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.LATE_TERM, "10:05", "11:35") ], "", [], "2023-09-06", "2023-12-08")
+        Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.MONDAY, TermDuration.EARLY_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.EARLY_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08"),
+        Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.LATE_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.LATE_TERM, "10:05", "11:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     ]
     assert scheduler.is_section_schedulable(section1, schedule) == False
     assert scheduler.is_section_schedulable(section2, schedule) == False
@@ -25,13 +25,13 @@ def test_is_section_schedulable():
 
 
 def test_are_sections_schedulable():
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [], "2023-09-06", "2023-12-08")
-    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     schedule = [
-        Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08"),
-        Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "10:05", "11:35") ], "", [], "2023-09-06", "2023-12-08")
+        Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08"),
+        Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "10:05", "11:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     ]
     assert scheduler.are_sections_schedulable([section1, section2, section3, section4], schedule) == False
     assert scheduler.are_sections_schedulable([section4, section1], schedule) == False
@@ -39,20 +39,20 @@ def test_are_sections_schedulable():
     assert scheduler.are_sections_schedulable([section3, section4], schedule) == True
 
 def test_do_section_times_overlap():
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [], "2023-09-06", "2023-12-08")
-    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE2000", "B", "22222", "Bob", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "C", "33333", "Charlie", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE3000", "C", "33333", "Charlie", [], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     assert scheduler.do_section_times_overlap([section1, section2]) == True
     assert scheduler.do_section_times_overlap([section1, section3, section4]) == False
     assert scheduler.do_section_times_overlap([section2, section3, section4]) == False
     assert scheduler.do_section_times_overlap([section1]) == False
 
 def test_get_related_section_combinations():
-    section1 = Section("CODE1000", "A", "11111", "Alice", [], "", [["B"], ["C", "D"]], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE2000", "B", "22222", "Bob", [], "", [], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE3000", "C", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
-    section4 = Section("CODE3000", "D", "33333", "Charlie", [], "", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [], "", "TITLE", "TERM", "NONE", [["B"], ["C", "D"]], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE2000", "B", "22222", "Bob", [], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE3000", "C", "33333", "Charlie", [], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE3000", "D", "33333", "Charlie", [], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     course = Course("", "", "", "", [section1], [section2, section3, section4], "")
     assert scheduler.get_related_section_combinations(course, section1) == [[section2, section3], [section2, section4]]
 
@@ -82,8 +82,8 @@ def test_can_take_together():
     '''
     LECTURE_SECTION_ID = "A"
     LAB_SECTION_ID = "L01"
-    lecture_section = Section("CODE1234", LECTURE_SECTION_ID, "54321", "Jill", [], "", [[LAB_SECTION_ID]], "2023-09-06", "2023-12-08")
-    lab_section = Section("CODE1234", LAB_SECTION_ID, "54321", "Jill", [], "", [["Z", "Q"], [LECTURE_SECTION_ID]], "2023-09-06", "2023-12-08")
+    lecture_section = Section("CODE1234", LECTURE_SECTION_ID, "54321", "Jill", [], "", "CLASS TITLE", "TERM", "NONE", [[LAB_SECTION_ID]], "2023-09-06", "2023-12-08")
+    lab_section = Section("CODE1234", LAB_SECTION_ID, "54321", "Jill", [], "", "CLASS TITLE", "TERM", "NONE", [["Z", "Q"], [LECTURE_SECTION_ID]], "2023-09-06", "2023-12-08")
     assert scheduler.can_take_together(lecture_section, lab_section) == True
     lecture_section.related_section_ids.pop()
     assert scheduler.can_take_together(lecture_section, lab_section) == False
@@ -95,7 +95,7 @@ def test_generate_schedules_with_no_courses():
     Tests that generateSchedules function can handle empty courses list
     '''
     schedule = [
-        Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
+        Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     ]
     assert scheduler.generate_schedules([], schedule) == [schedule]
 
@@ -105,9 +105,9 @@ def test_generate_schedules_with_max_schedules():
     '''
     max_schedules = scheduler.MAX_SCHEDULES
     scheduler.MAX_SCHEDULES = 1
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["L"]], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "B", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["L"]], "2023-09-06", "2023-12-08")
-    sectionL = Section("CODE1000", "L", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", [["A", "B"]], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [["L"]], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "B", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [["L"]], "2023-09-06", "2023-12-08")
+    sectionL = Section("CODE1000", "L", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", "CLASS TITLE", "TERM", "NONE", [["A", "B"]], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1, section2], [sectionL], None)
     schedule = [
         section1,
@@ -121,11 +121,11 @@ def test_generate_schedules_with_lab_sections():
     '''
     Tests that the generateSchedules function can schedule courses with lab sections
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [["L1", "L2"]], "2023-09-06", "2023-12-08")
-    section2A = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["A"]], "2023-09-06", "2023-12-08")
-    section2B = Section("CODE1000", "L2", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", [["A"]], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section4 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [["L1", "L2"]], "2023-09-06", "2023-12-08")
+    section2A = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [["A"]], "2023-09-06", "2023-12-08")
+    section2B = Section("CODE1000", "L2", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", "CLASS TITLE", "TERM", "NONE", [["A"]], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [section2A, section2B], None)
     schedule1 = [
         section3, section4
@@ -143,9 +143,9 @@ def test_generate_schedules_without_lab_sections():
     '''
     Test that the generateSchedules function can schedule courses without lab section
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [], None)
     schedule1 = [
         section2, section3
@@ -161,9 +161,9 @@ def test_generate_schedules_with_incompatible_lab():
     '''
     Tests the generateSchedules function with incomptible lecture/lab sections
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [["A1"]], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "A1", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["A"]], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE1000", "B1", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["B"]], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [["A1"]], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "A1", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [["A"]], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE1000", "B1", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [["B"]], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [section2, section3], None)
     expected_schedule = [
        section1, section2
@@ -175,10 +175,10 @@ def test_generate_schedules_with_unschedulable_section():
     '''
     Tests the generateSchedules function unschedulable lecture AND lab section
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [["L1"]], "2023-09-06", "2023-12-08")
-    section2 = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "13:55")], "", [["A"]], "2023-09-06", "2023-12-08")
-    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section4 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.WEDNESDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [["L1"]], "2023-09-06", "2023-12-08")
+    section2 = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "13:55")], "", "CLASS TITLE", "TERM", "NONE", [["A"]], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE5000", "E", "55555", "Eric", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "11:05", "12:35"), ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [section2], None)
     course2 = Course("CODE4000", "TESTCLASS2", "Fall 2023", "NONE", [section3], [], None)
     schedule1 = [
@@ -191,13 +191,13 @@ def test_generate_schedules_with_lab_and_tutorials():
     '''
     Tests that the generateSchedules function can schedule courses with lab sections and tutorial sections
     '''
-    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["ETU"], ["L1", "L2"]], "2023-09-06", "2023-12-08")
-    section2A = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", [["A"]], "2023-09-06", "2023-12-08")
-    section2B = Section("CODE1000", "L2", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", [["A"]], "2023-09-06", "2023-12-08")
-    section2C = Section("CODE1000", "ETU", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "20:05", "21:35")], "", [["A"]], "2023-09-06", "2023-12-08")
+    section1 = Section("CODE1000", "A", "11111", "Alice", [ClassTime(DayOfWeek.MONDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [["ETU"], ["L1", "L2"]], "2023-09-06", "2023-12-08")
+    section2A = Section("CODE1000", "L1", "12345", "Alice", [ClassTime(DayOfWeek.TUESDAY, TermDuration.FULL_TERM, "09:05", "10:35")], "", "CLASS TITLE", "TERM", "NONE", [["A"]], "2023-09-06", "2023-12-08")
+    section2B = Section("CODE1000", "L2", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "19:05", "20:35")], "", "CLASS TITLE", "TERM", "NONE", [["A"]], "2023-09-06", "2023-12-08")
+    section2C = Section("CODE1000", "ETU", "12345", "Alice", [ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "20:05", "21:35")], "", "CLASS TITLE", "TERM", "NONE", [["A"]], "2023-09-06", "2023-12-08")
     
-    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", [], "2023-09-06", "2023-12-08")
-    section4 = Section("CODE4000", "E", "55555", "Eric", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", [], "2023-09-06", "2023-12-08")
+    section3 = Section("CODE4000", "D", "44444", "Dom", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "09:05", "10:35"), ClassTime(DayOfWeek.FRIDAY, TermDuration.FULL_TERM, "09:05", "10:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
+    section4 = Section("CODE4000", "E", "55555", "Eric", [ClassTime(DayOfWeek.THURSDAY, TermDuration.FULL_TERM, "12:05", "13:35") ], "", "CLASS TITLE", "TERM", "NONE", [], "2023-09-06", "2023-12-08")
     
     course1 = Course("CODE1000", "TESTCLASS", "Fall 2023", "NONE", [section1], [section2A, section2B, section2C], None)
     course2 = Course("CODE4000", "TESTCLASS", "Fall 2023", "NONE", [section3, section4], [], None)

--- a/Backend/tests/unit/test_section.py
+++ b/Backend/tests/unit/test_section.py
@@ -8,9 +8,14 @@ def test_to_dict():
     instructor = "Professor X"
     times = []
     status = "OPEN"
+    title = "COURSE TITLE"
+    term = "Fall 2023"
+    prerequisite = "None"
     related_sections = []
     start_date = "2023-09-06"
     end_date = "2023-12-08"
-    section = Section(course_code, section_id, crn, instructor, times, status, related_sections, start_date, end_date)
+    section = Section(course_code, section_id, crn, instructor, times, status, title, term, prerequisite, related_sections, start_date, end_date)
     assert section.to_dict() == {"CourseCode":course_code, "SectionID":section_id, "CRN":crn,
-                                 "Instructor":instructor, "Times":times, "Status":status, "StartDate": start_date, "EndDate": end_date}
+                                 "Instructor":instructor, "Times":times, "Status":status, 
+                                 "StartDate": start_date, "EndDate": end_date, "Title": title,
+                                 "Term": term, "Prerequisite": prerequisite}


### PR DESCRIPTION
"generateSchedules" API now returns the title, term, and prerequisite information for each section.